### PR TITLE
[FEAT] 성공/실패 공통 응답 형식 통일

### DIFF
--- a/src/main/java/AIFinance/demo/global/apiPayload/ApiResponse.java
+++ b/src/main/java/AIFinance/demo/global/apiPayload/ApiResponse.java
@@ -1,0 +1,35 @@
+package AIFinance.demo.global.apiPayload;
+
+import AIFinance.demo.global.apiPayload.code.BaseErrorCode;
+import AIFinance.demo.global.apiPayload.code.BaseSuccessCode;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@JsonPropertyOrder({"isSuccess", "code", "message", "result"})
+public class ApiResponse<T> {
+    @JsonProperty("isSuccess")
+    private final Boolean isSuccess;
+
+    @JsonProperty("code")
+    private final String code;
+
+    @JsonProperty("message")
+    private final String message;
+
+    @JsonProperty("result")
+    private T result;
+
+    // 성공한 경우 (result 포함)
+    public static <T> ApiResponse<T> onSuccess(BaseSuccessCode code, T result){
+        return new ApiResponse<>(true, code.getCode(), code.getMessage(), result);
+    }
+
+    // 실패한 경우 (result 포함)
+    public static <T> ApiResponse<T> onFailure(BaseErrorCode code, T result) {
+        return new ApiResponse<>(false, code.getCode(), code.getMessage(), result);
+    }
+}

--- a/src/main/java/AIFinance/demo/global/apiPayload/code/BaseErrorCode.java
+++ b/src/main/java/AIFinance/demo/global/apiPayload/code/BaseErrorCode.java
@@ -1,0 +1,9 @@
+package AIFinance.demo.global.apiPayload.code;
+
+import org.springframework.http.HttpStatus;
+
+public interface BaseErrorCode {
+    HttpStatus getStatus();
+    String getCode();
+    String getMessage();
+}

--- a/src/main/java/AIFinance/demo/global/apiPayload/code/BaseSuccessCode.java
+++ b/src/main/java/AIFinance/demo/global/apiPayload/code/BaseSuccessCode.java
@@ -1,0 +1,9 @@
+package AIFinance.demo.global.apiPayload.code;
+
+import org.springframework.http.HttpStatus;
+
+public interface BaseSuccessCode {
+    HttpStatus getStatus();
+    String getCode();
+    String getMessage();
+}

--- a/src/main/java/AIFinance/demo/global/apiPayload/code/GeneralErrorCode.java
+++ b/src/main/java/AIFinance/demo/global/apiPayload/code/GeneralErrorCode.java
@@ -1,0 +1,30 @@
+package AIFinance.demo.global.apiPayload.code;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter@AllArgsConstructor
+public enum GeneralErrorCode implements BaseErrorCode{
+    BAD_REQUEST(HttpStatus.BAD_REQUEST,
+            "COMMON_BAD_REQUEST",
+            "잘못된 요청입니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED,
+            "AUTH_UNAUTHORIZED",
+            "인증이 필요합니다."),
+    FORBIDDEN(HttpStatus.FORBIDDEN,
+            "AUTH_FORBIDDEN",
+            "요청이 거부되었습니다."),
+    NOT_FOUND(HttpStatus.NOT_FOUND,
+            "COMMON_NOT_FOUND",
+            "요청한 리소스를 찾을 수 없습니다."),
+    INTERNAL_SERVER_ERROR(
+            HttpStatus.INTERNAL_SERVER_ERROR,
+            "COMMON_INTERNAL_SERVER_ERROR",
+            "서버 내부 오류가 발생했습니다."
+    );
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/AIFinance/demo/global/apiPayload/code/GeneralSuccessCode.java
+++ b/src/main/java/AIFinance/demo/global/apiPayload/code/GeneralSuccessCode.java
@@ -1,0 +1,28 @@
+package AIFinance.demo.global.apiPayload.code;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum GeneralSuccessCode implements BaseSuccessCode{
+    OK(HttpStatus.OK,
+            "COMMON_OK",
+            "요청이 성공적으로 처리되었습니다."
+    ),
+
+    CREATED(HttpStatus.CREATED,
+            "COMMON_CREATED",
+            "리소스가 성공적으로 생성되었습니다."
+    ),
+
+    ACCEPTED(HttpStatus.ACCEPTED,
+            "COMMON_ACCEPTED",
+            "요청이 접수되었습니다."
+    );
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}


### PR DESCRIPTION
## 관련 이슈

Closes #1

## 작업 내용

API의 성공 및 실패 응답 형식을 일관되게 관리하기 위한 공통 응답 구조를 구현했습니다.

## 주요 변경 사항

- `ApiResponse<T>` 공통 응답 클래스 추가
- 성공 및 실패 코드 인터페이스 추가
- 공통 성공 응답 코드 정의
- 공통 실패 응답 코드 정의
- 응답을 `isSuccess`, `code`, `message`, `result` 형식으로 통일
