### PR TITLE
[FEAT] 전역 예외 처리 구현

### DIFF
--- a/src/main/java/AIFinance/demo/global/apiPayload/exception/GeneralException.java
+++ b/src/main/java/AIFinance/demo/global/apiPayload/exception/GeneralException.java
@@ -1,0 +1,12 @@
+package AIFinance.demo.global.apiPayload.exception;
+
+import AIFinance.demo.global.apiPayload.code.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class GeneralException extends RuntimeException {
+
+    private final BaseErrorCode code;
+}

--- a/src/main/java/AIFinance/demo/global/apiPayload/handler/GeneralExceptionAdvice.java
+++ b/src/main/java/AIFinance/demo/global/apiPayload/handler/GeneralExceptionAdvice.java
@@ -1,0 +1,42 @@
+package AIFinance.demo.global.apiPayload.handler;
+
+import AIFinance.demo.global.apiPayload.ApiResponse;
+import AIFinance.demo.global.apiPayload.code.BaseErrorCode;
+import AIFinance.demo.global.apiPayload.code.GeneralErrorCode;
+import AIFinance.demo.global.apiPayload.exception.GeneralException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GeneralExceptionAdvice {
+
+    // 애플리케이션에서 발생하는 커스텀 예외를 처리
+    @ExceptionHandler(GeneralException.class)
+    public ResponseEntity<ApiResponse<Void>> handleException(
+            GeneralException ex
+    ) {
+
+        return ResponseEntity.status(ex.getCode().getStatus())
+                .body(ApiResponse.onFailure(
+                                ex.getCode(),
+                                null
+                        )
+                );
+    }
+
+    // 그 외의 정의되지 않은 모든 예외 처리
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<String>> handleException(
+            Exception ex
+    ) {
+        
+        BaseErrorCode code = GeneralErrorCode.INTERNAL_SERVER_ERROR;
+        return ResponseEntity.status(code.getStatus())
+                .body(ApiResponse.onFailure(
+                                code,
+                                ex.getMessage()
+                        )
+                );
+    }
+}


### PR DESCRIPTION
## 관련 이슈

Closes #3

## 작업 내용

애플리케이션에서 발생하는 예외를 공통 응답 형식으로 처리하기 위한 전역 예외 처리 구조를 구현했습니다.

## 주요 변경 사항

- 공통 커스텀 예외 `GeneralException` 추가
- `@RestControllerAdvice` 기반 전역 예외 처리 구현
- 커스텀 예외의 HTTP 상태 코드 및 공통 실패 응답 처리
- 정의되지 않은 예외의 `500 Internal Server Error` 처리

## 예외 처리 흐름

- `GeneralException` 발생 시 해당 `BaseErrorCode`의 상태 코드와 메시지를 반환합니다.
- 정의되지 않은 예외는 `INTERNAL_SERVER_ERROR`로 처리합니다.
- 도메인별 오류 코드는 각 도메인 개발 과정에서 추가할 예정입니다.

## 응답 예시

```json
{
  "isSuccess": false,
  "code": "COMMON_INTERNAL_SERVER_ERROR",
  "message": "서버 내부 오류가 발생했습니다.",
  "result": null
}