### PR TITLE
[CHORE] BaseEntity 및 JPA Auditing 설정

### DIFF
--- a/src/main/java/AIFinance/demo/DemoApplication.java
+++ b/src/main/java/AIFinance/demo/DemoApplication.java
@@ -2,7 +2,9 @@ package AIFinance.demo;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class DemoApplication {
 

--- a/src/main/java/AIFinance/demo/global/entity/BaseEntity.java
+++ b/src/main/java/AIFinance/demo/global/entity/BaseEntity.java
@@ -1,0 +1,24 @@
+package AIFinance.demo.global.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+public abstract class BaseEntity {
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+}


### PR DESCRIPTION
## 관련 이슈
Closes #5

## 작업 내용
<!-- 이 PR에서 진행한 작업을 간단히 설명해주세요. -->
- Entity의 생성·수정 시간을 공통으로 관리하기 위한 `BaseEntity`를 추가했습니다.
- JPA Auditing을 활성화했습니다.

## 주요 변경 사항
<!-- 주요 변경 사항을 작성해주세요. -->
- `BaseEntity`에 `createdAt`, `updatedAt` 공통 필드 추가
- `@CreatedDate`, `@LastModifiedDate`를 통한 시간 자동 기록
- `@EnableJpaAuditing`을 통한 JPA Auditing 활성화

## 동작 흐름
<!-- 변경된 기능의 동작 흐름이나 처리 과정을 작성해주세요. 해당하지 않는 경우 삭제해주세요. -->
-
-
-

## 응답 예시
<!-- API 응답이나 실행 결과가 있다면 작성해주세요. 해당하지 않는 경우 삭제해주세요. -->

```json
{
}
```

## AI 사용 여부
- [ ] 사용함
- [x] 사용하지 않음

### 사용한 AI 기능
<!-- AI를 사용한 경우에만 작성해주세요. -->

- AI 기능/도구:
- 사용 범위:
- 생성된 코드 직접 검토 여부: [ ] Yes
- AI 생성 코드를 수정했나요?: [ ] Yes / [ ] No

## 팀원이 확인해야 할 것

<!-- 리뷰 시 중점적으로 확인해야 할 내용이 있다면 작성해주세요. -->

-
