### PR TITLE
[FEAT] 여행 및 영수증 도메인 엔티티 구현

### DIFF
--- a/src/main/java/AIFinance/demo/receipt/entity/Receipt.java
+++ b/src/main/java/AIFinance/demo/receipt/entity/Receipt.java
@@ -1,0 +1,64 @@
+package AIFinance.demo.receipt.entity;
+
+import AIFinance.demo.global.entity.BaseEntity;
+import AIFinance.demo.receipt.entity.enums.ReceiptAnalysisStatus;
+import AIFinance.demo.receipt.entity.enums.ReceiptInputType;
+import AIFinance.demo.receipt.entity.enums.ReceiptStatus;
+import AIFinance.demo.trip.entity.Trip;
+import AIFinance.demo.trip.entity.TripMember;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Builder
+@Getter
+@Table(name = "receipts")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class Receipt extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "receipt_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "trip_id", nullable = false)
+    private Trip trip;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "uploader_member_id", nullable = false)
+    private TripMember uploaderMember;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "payer_member_id")
+    private TripMember payerMember;
+
+    @Column(name = "image_url", length = 500)
+    private String imageUrl;
+
+    @Column(name = "merchant_name", length = 150)
+    private String merchantName;
+
+    @Column(name = "paid_at")
+    private LocalDateTime paidAt;
+
+    @Column(name = "total_amount")
+    private Long totalAmount;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "input_type", nullable = false, length = 20)
+    @Builder.Default
+    private ReceiptInputType inputType = ReceiptInputType.AI;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    @Builder.Default
+    private ReceiptStatus status = ReceiptStatus.ACTIVE;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "analysis_status", nullable = false, length = 20)
+    @Builder.Default
+    private ReceiptAnalysisStatus analysisStatus = ReceiptAnalysisStatus.PENDING;
+}

--- a/src/main/java/AIFinance/demo/receipt/entity/ReceiptItem.java
+++ b/src/main/java/AIFinance/demo/receipt/entity/ReceiptItem.java
@@ -1,0 +1,70 @@
+package AIFinance.demo.receipt.entity;
+
+import AIFinance.demo.global.entity.BaseEntity;
+import AIFinance.demo.receipt.entity.enums.SplitType;
+import AIFinance.demo.trip.entity.TripMember;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Builder
+@Getter
+@Table(name = "receipt_items")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ReceiptItem extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "item_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "receipt_id", nullable = false)
+    private Receipt receipt;
+
+    @Column(name = "item_name", nullable = false, length = 100)
+    private String itemName;
+
+    @Column(name = "quantity", nullable = false)
+    private Integer quantity;
+
+    @Column(name = "unit_price")
+    private Long unitPrice;
+
+    @Column(name = "original_amount", nullable = false)
+    private Long originalAmount;
+
+    @Column(name = "settlement_amount", nullable = false)
+    private Long settlementAmount;
+
+    @Column(name = "category", length = 50)
+    private String category;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "split_type", length = 20)
+    private SplitType splitType;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "remainder_member_id")
+    private TripMember remainderMember;
+
+    public static ReceiptItem createAdditionalCost(
+            Receipt receipt,
+            String itemName,
+            String category,
+            Long originalAmount,
+            Long settlementAmount
+    ) {
+        ReceiptItem item = new ReceiptItem();
+        item.receipt = receipt;
+        item.itemName = itemName;
+        item.quantity = 1;
+        item.unitPrice = originalAmount;
+        item.originalAmount = originalAmount;
+        item.settlementAmount = settlementAmount;
+        item.category = category;
+        return item;
+    }
+}
+

--- a/src/main/java/AIFinance/demo/receipt/entity/enums/ReceiptAnalysisStatus.java
+++ b/src/main/java/AIFinance/demo/receipt/entity/enums/ReceiptAnalysisStatus.java
@@ -1,0 +1,8 @@
+package AIFinance.demo.receipt.entity.enums;
+
+public enum ReceiptAnalysisStatus {
+    PENDING,
+    PROCESSING,
+    SUCCESS,
+    FAILED
+}

--- a/src/main/java/AIFinance/demo/receipt/entity/enums/ReceiptInputType.java
+++ b/src/main/java/AIFinance/demo/receipt/entity/enums/ReceiptInputType.java
@@ -1,0 +1,6 @@
+package AIFinance.demo.receipt.entity.enums;
+
+public enum ReceiptInputType {
+    AI,
+    MANUAL
+}

--- a/src/main/java/AIFinance/demo/receipt/entity/enums/ReceiptStatus.java
+++ b/src/main/java/AIFinance/demo/receipt/entity/enums/ReceiptStatus.java
@@ -1,0 +1,7 @@
+package AIFinance.demo.receipt.entity.enums;
+
+public enum ReceiptStatus {
+    ACTIVE,
+    CONFIRMED,
+    DELETED
+}

--- a/src/main/java/AIFinance/demo/receipt/entity/enums/SplitType.java
+++ b/src/main/java/AIFinance/demo/receipt/entity/enums/SplitType.java
@@ -1,0 +1,7 @@
+package AIFinance.demo.receipt.entity.enums;
+
+public enum SplitType {
+    EQUAL, // 선택 참여자 균등 분할
+    INDIVIDUAL, // 한명이 전액 부담
+    CUSTOM // 직접 지정
+}

--- a/src/main/java/AIFinance/demo/trip/entity/Trip.java
+++ b/src/main/java/AIFinance/demo/trip/entity/Trip.java
@@ -1,0 +1,49 @@
+package AIFinance.demo.trip.entity;
+
+import AIFinance.demo.global.entity.BaseEntity;
+import AIFinance.demo.trip.entity.enums.TripStatus;
+import AIFinance.demo.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@Builder
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(name = "trips")
+public class Trip extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "trip_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "owner_id", nullable = false)
+    private User owner;
+
+    @Column(name = "name", nullable = false, length = 100)
+    private String name;
+
+    @Column(name = "start_date", nullable = false)
+    private LocalDate startDate;
+
+    @Column(name = "end_date", nullable = false)
+    private LocalDate endDate;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    @Builder.Default
+    private TripStatus status = TripStatus.ACTIVE;
+
+    @Column(name = "invite_code", nullable = false, unique = true, length = 100)
+    private String inviteCode;
+
+    @Column(name = "invite_expires_at")
+    private LocalDateTime inviteExpiresAt;
+
+
+}

--- a/src/main/java/AIFinance/demo/trip/entity/TripMember.java
+++ b/src/main/java/AIFinance/demo/trip/entity/TripMember.java
@@ -1,0 +1,59 @@
+package AIFinance.demo.trip.entity;
+
+import AIFinance.demo.trip.entity.enums.TripMemberRole;
+import AIFinance.demo.trip.entity.enums.TripMemberStatus;
+import AIFinance.demo.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Builder
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(name = "trip_members",
+        uniqueConstraints = {
+            @UniqueConstraint(
+                    name = "uk_trip_members_trip_user",
+                    columnNames = {"trip_id", "user_id"}
+            )
+        })
+public class TripMember {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "trip_member_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "trip_id", nullable = false)
+    private Trip trip;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "role", nullable = false, length = 20)
+    @Builder.Default
+    private TripMemberRole role = TripMemberRole.MEMBER;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    @Builder.Default
+    private TripMemberStatus status = TripMemberStatus.ACTIVE;
+
+    @Column(name = "joined_at", nullable = false, updatable = false)
+    private LocalDateTime joinedAt;
+
+    @Column(name = "left_at")
+    private LocalDateTime leftAt;
+
+    @PrePersist
+    protected void onCreate() {
+        if (joinedAt == null) {
+            joinedAt = LocalDateTime.now();
+        }
+    }
+}

--- a/src/main/java/AIFinance/demo/trip/entity/enums/TripMemberRole.java
+++ b/src/main/java/AIFinance/demo/trip/entity/enums/TripMemberRole.java
@@ -1,0 +1,6 @@
+package AIFinance.demo.trip.entity.enums;
+
+public enum TripMemberRole {
+    OWNER,
+    MEMBER
+}

--- a/src/main/java/AIFinance/demo/trip/entity/enums/TripMemberStatus.java
+++ b/src/main/java/AIFinance/demo/trip/entity/enums/TripMemberStatus.java
@@ -1,0 +1,5 @@
+package AIFinance.demo.trip.entity.enums;
+
+public enum TripMemberStatus {
+    ACTIVE
+}

--- a/src/main/java/AIFinance/demo/trip/entity/enums/TripStatus.java
+++ b/src/main/java/AIFinance/demo/trip/entity/enums/TripStatus.java
@@ -1,0 +1,7 @@
+package AIFinance.demo.trip.entity.enums;
+
+public enum TripStatus {
+    ACTIVE, // 영수증, 상품, 부담내역 수정 가능
+    SETTLING, // 정산 확정, 송금 진행 중
+    COMPLETED // 모든 송금 확인 후 정산 완료
+}

--- a/src/main/java/AIFinance/demo/user/entity/User.java
+++ b/src/main/java/AIFinance/demo/user/entity/User.java
@@ -1,0 +1,35 @@
+package AIFinance.demo.user.entity;
+
+import AIFinance.demo.global.entity.BaseEntity;
+import AIFinance.demo.user.entity.enums.UserStatus;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Builder
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(name = "users")
+public class User extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id")
+    private Long id;
+
+    @Column(name = "email", nullable = false, unique = true, length = 255)
+    private String email;
+
+    @Column(name = "password", nullable = false, length = 255)
+    private String password;
+
+    @Column(name = "nickname", nullable = false, length = 50)
+    private String nickname;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    @Builder.Default
+    private UserStatus status = UserStatus.ACTIVE;
+
+}

--- a/src/main/java/AIFinance/demo/user/entity/enums/UserStatus.java
+++ b/src/main/java/AIFinance/demo/user/entity/enums/UserStatus.java
@@ -1,0 +1,5 @@
+package AIFinance.demo.user.entity.enums;
+
+public enum UserStatus {
+    ACTIVE
+}


### PR DESCRIPTION
## 관련 이슈
Closes #7

## 작업 내용
<!-- 이 PR에서 진행한 작업을 간단히 설명해주세요. -->
- COST API 구현에 필요한 사용자, 여행, 영수증 도메인 Entity와 Enum을 구현했습니다.
- ERD를 기준으로 연관관계와 데이터베이스 제약조건을 설정했습니다.

## 주요 변경 사항
<!-- 주요 변경 사항을 작성해주세요. -->
- `User`, `Trip`, `TripMember`, `Receipt`, `ReceiptItem` Entity 추가
- 여행, 참여자, 영수증, 분석 및 분할 상태 Enum 추가
- Entity 간 `ManyToOne` 연관관계 및 `(trip_id, user_id)` UNIQUE 제약조건 설정
- 원화 금액 필드에 `Long` 타입 적용
- `TripMember.joinedAt` 자동 기록 및 추가 비용 항목 생성 메서드 구현

## 동작 흐름
<!-- 변경된 기능의 동작 흐름이나 처리 과정을 작성해주세요. 해당하지 않는 경우 삭제해주세요. -->
- Entity 저장 시 식별자가 자동 생성됩니다.
- `BaseEntity`를 상속한 Entity의 생성·수정 시간이 JPA Auditing으로 기록됩니다.
- `TripMember` 저장 시 `joinedAt`이 자동으로 설정됩니다.

## AI 사용 여부
- [ ] 사용함
- [ ] 사용하지 않음

### 사용한 AI 기능
<!-- AI를 사용한 경우에만 작성해주세요. -->

- AI 기능/도구:
- 사용 범위:
- 생성된 코드 직접 검토 여부: [ ] Yes
- AI 생성 코드를 수정했나요?: [ ] Yes / [ ] No

## 팀원이 확인해야 할 것

<!-- 리뷰 시 중점적으로 확인해야 할 내용이 있다면 작성해주세요. -->

- 상태 Enum 값과 nullable 조건이 기능 명세에 맞는지 확인 부탁드립니다.
- `compileJava`는 성공했으나 공통 DataSource 설정이 아직 없어 애플리케이션 구동 테스트는 진행하지 못했습니다.
