### PR TITLE
[FEAT] 추가 비용 항목 등록 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,8 @@ dependencies {
 	testCompileOnly 'org.projectlombok:lombok'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	testAnnotationProcessor 'org.projectlombok:lombok'
+
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 }
 
 tasks.named('test') {

--- a/src/main/java/AIFinance/demo/receipt/controller/ReceiptItemController.java
+++ b/src/main/java/AIFinance/demo/receipt/controller/ReceiptItemController.java
@@ -1,0 +1,33 @@
+package AIFinance.demo.receipt.controller;
+
+import AIFinance.demo.global.apiPayload.ApiResponse;
+import AIFinance.demo.receipt.dto.ReceiptItemRequest;
+import AIFinance.demo.receipt.dto.ReceiptItemResponse;
+import AIFinance.demo.receipt.exception.code.ReceiptItemSuccessCode;
+import AIFinance.demo.receipt.service.ReceiptItemService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/trips/{tripId}/receipts/{receiptId}/items")
+public class ReceiptItemController {
+    private final ReceiptItemService receiptItemService;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<ReceiptItemResponse.CreatedAdditionalCost>> createAdditionalCost(
+            @RequestHeader("X-USER-ID") Long userId,
+            @PathVariable Long tripId,
+            @PathVariable Long receiptId,
+            @Valid @RequestBody ReceiptItemRequest.CreateAdditionalCost request
+    ){
+        ReceiptItemResponse.CreatedAdditionalCost result = receiptItemService.createAdditionalCost(userId, tripId, receiptId, request);
+        ReceiptItemSuccessCode successCode = ReceiptItemSuccessCode.ADDITIONAL_COST_CREATED;
+
+        return ResponseEntity
+                .status(successCode.getStatus())
+                .body(ApiResponse.onSuccess(successCode, result));
+    }
+}

--- a/src/main/java/AIFinance/demo/receipt/dto/ReceiptItemRequest.java
+++ b/src/main/java/AIFinance/demo/receipt/dto/ReceiptItemRequest.java
@@ -1,0 +1,23 @@
+package AIFinance.demo.receipt.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
+
+public class ReceiptItemRequest {
+
+    private ReceiptItemRequest() {
+    }
+
+    public record CreateAdditionalCost(
+            @NotBlank(message = "항목명은 필수입니다.")
+            @Size(max = 100, message = "항목명은 100자 이하여야 합니다.")
+            String itemName,
+
+            @NotNull(message = "금액은 필수입니다.")
+            @Positive(message = "금액은 1원 이상이어야 합니다.")
+            Long amount
+    ) {
+    }
+}

--- a/src/main/java/AIFinance/demo/receipt/dto/ReceiptItemResponse.java
+++ b/src/main/java/AIFinance/demo/receipt/dto/ReceiptItemResponse.java
@@ -1,0 +1,30 @@
+package AIFinance.demo.receipt.dto;
+
+import AIFinance.demo.receipt.entity.ReceiptItem;
+
+public class ReceiptItemResponse {
+
+    private ReceiptItemResponse() {
+    }
+
+    public record CreatedAdditionalCost(
+            Long itemId,
+            Long receiptId,
+            String itemName,
+            Integer quantity,
+            Long originalAmount,
+            Long settlementAmount
+    ) {
+
+        public static CreatedAdditionalCost from(ReceiptItem item) {
+            return new CreatedAdditionalCost(
+                    item.getId(),
+                    item.getReceipt().getId(),
+                    item.getItemName(),
+                    item.getQuantity(),
+                    item.getOriginalAmount(),
+                    item.getSettlementAmount()
+            );
+        }
+    }
+}

--- a/src/main/java/AIFinance/demo/receipt/entity/ReceiptItem.java
+++ b/src/main/java/AIFinance/demo/receipt/entity/ReceiptItem.java
@@ -52,18 +52,17 @@ public class ReceiptItem extends BaseEntity {
     public static ReceiptItem createAdditionalCost(
             Receipt receipt,
             String itemName,
-            String category,
-            Long originalAmount,
-            Long settlementAmount
+            Long amount
     ) {
         ReceiptItem item = new ReceiptItem();
         item.receipt = receipt;
         item.itemName = itemName;
         item.quantity = 1;
-        item.unitPrice = originalAmount;
-        item.originalAmount = originalAmount;
-        item.settlementAmount = settlementAmount;
-        item.category = category;
+        item.unitPrice = amount;
+        item.originalAmount = amount;
+        item.settlementAmount = amount;
+        item.category = "ADDITIONAL_COST";
+
         return item;
     }
 }

--- a/src/main/java/AIFinance/demo/receipt/exception/ReceiptItemException.java
+++ b/src/main/java/AIFinance/demo/receipt/exception/ReceiptItemException.java
@@ -1,0 +1,10 @@
+package AIFinance.demo.receipt.exception;
+
+import AIFinance.demo.global.apiPayload.code.BaseErrorCode;
+import AIFinance.demo.global.apiPayload.exception.GeneralException;
+
+public class ReceiptItemException extends GeneralException {
+  public ReceiptItemException(BaseErrorCode code) {
+    super(code);
+  }
+}

--- a/src/main/java/AIFinance/demo/receipt/exception/code/ReceiptItemErrorCode.java
+++ b/src/main/java/AIFinance/demo/receipt/exception/code/ReceiptItemErrorCode.java
@@ -1,0 +1,44 @@
+package AIFinance.demo.receipt.exception.code;
+
+import AIFinance.demo.global.apiPayload.code.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ReceiptItemErrorCode implements BaseErrorCode {
+    TRIP_NOT_FOUND(
+            HttpStatus.NOT_FOUND,
+            "TRIP_NOT_FOUND",
+            "여행방을 찾을 수 없습니다."
+    ),
+
+    TRIP_MEMBER_REQUIRED(
+            HttpStatus.FORBIDDEN,
+            "TRIP_MEMBER_REQUIRED",
+            "해당 여행방의 참여자만 요청할 수 있습니다."
+    ),
+
+    INVALID_TRIP_STATUS(
+            HttpStatus.CONFLICT,
+            "INVALID_TRIP_STATUS",
+            "정산이 진행 중이거나 완료된 여행방은 수정할 수 없습니다."
+    ),
+
+    RECEIPT_NOT_FOUND(
+            HttpStatus.NOT_FOUND,
+            "RECEIPT_NOT_FOUND",
+            "해당 여행방에서 영수증을 찾을 수 없습니다."
+    ),
+
+    RECEIPT_DELETED(
+            HttpStatus.CONFLICT,
+            "RECEIPT_DELETED",
+            "삭제된 영수증에는 추가 비용을 등록할 수 없습니다."
+    );
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/AIFinance/demo/receipt/exception/code/ReceiptItemSuccessCode.java
+++ b/src/main/java/AIFinance/demo/receipt/exception/code/ReceiptItemSuccessCode.java
@@ -1,0 +1,21 @@
+package AIFinance.demo.receipt.exception.code;
+
+import AIFinance.demo.global.apiPayload.code.BaseSuccessCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ReceiptItemSuccessCode implements BaseSuccessCode {
+
+    ADDITIONAL_COST_CREATED(
+            HttpStatus.CREATED,
+            "ADDITIONAL_COST_CREATED",
+            "추가 비용 항목이 등록되었습니다."
+    );
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/AIFinance/demo/receipt/repository/ReceiptItemRepository.java
+++ b/src/main/java/AIFinance/demo/receipt/repository/ReceiptItemRepository.java
@@ -1,0 +1,9 @@
+package AIFinance.demo.receipt.repository;
+
+import AIFinance.demo.receipt.entity.ReceiptItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+
+public interface ReceiptItemRepository extends JpaRepository<ReceiptItem, Long> {
+
+}

--- a/src/main/java/AIFinance/demo/receipt/repository/ReceiptRepository.java
+++ b/src/main/java/AIFinance/demo/receipt/repository/ReceiptRepository.java
@@ -1,0 +1,11 @@
+package AIFinance.demo.receipt.repository;
+
+import AIFinance.demo.receipt.entity.Receipt;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ReceiptRepository extends JpaRepository<Receipt, Long> {
+    // 여행방과 영수증 조회
+    Optional<Receipt> findByIdAndTrip_Id(Long receiptId, Long tripId);
+}

--- a/src/main/java/AIFinance/demo/receipt/service/ReceiptItemService.java
+++ b/src/main/java/AIFinance/demo/receipt/service/ReceiptItemService.java
@@ -1,0 +1,69 @@
+package AIFinance.demo.receipt.service;
+
+import AIFinance.demo.receipt.dto.ReceiptItemRequest;
+import AIFinance.demo.receipt.dto.ReceiptItemResponse;
+import AIFinance.demo.receipt.entity.Receipt;
+import AIFinance.demo.receipt.entity.ReceiptItem;
+import AIFinance.demo.receipt.entity.enums.ReceiptStatus;
+import AIFinance.demo.receipt.exception.ReceiptItemException;
+import AIFinance.demo.receipt.exception.code.ReceiptItemErrorCode;
+import AIFinance.demo.receipt.repository.ReceiptItemRepository;
+import AIFinance.demo.receipt.repository.ReceiptRepository;
+import AIFinance.demo.trip.entity.Trip;
+import AIFinance.demo.trip.entity.enums.TripMemberStatus;
+import AIFinance.demo.trip.entity.enums.TripStatus;
+import AIFinance.demo.trip.repository.TripMemberRepository;
+import AIFinance.demo.trip.repository.TripRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ReceiptItemService {
+    private final TripRepository tripRepository;
+    private final TripMemberRepository tripMemberRepository;
+    private final ReceiptRepository receiptRepository;
+    private final ReceiptItemRepository receiptItemRepository;
+
+    @Transactional
+    public ReceiptItemResponse.CreatedAdditionalCost createAdditionalCost(Long userId, Long tripId, Long receiptId, ReceiptItemRequest.CreateAdditionalCost request) {
+        Trip trip = tripRepository.findById(tripId)
+                .orElseThrow(() -> new ReceiptItemException(ReceiptItemErrorCode.TRIP_NOT_FOUND));
+
+        validateTripStatus(trip);
+        validateTripMember(tripId, userId);
+
+        Receipt receipt = receiptRepository.findByIdAndTrip_Id(receiptId, tripId)
+                .orElseThrow(() -> new ReceiptItemException(ReceiptItemErrorCode.RECEIPT_NOT_FOUND));
+
+        validateReceiptStatus(receipt);
+
+        ReceiptItem receiptItem = ReceiptItem.createAdditionalCost(receipt, request.itemName(), request.amount());
+        ReceiptItem savedItem = receiptItemRepository.save(receiptItem);
+
+        return ReceiptItemResponse.CreatedAdditionalCost.from(savedItem);
+
+    }
+
+    private void validateTripStatus(Trip trip) {
+        if (trip.getStatus() != TripStatus.ACTIVE) {
+            throw new ReceiptItemException(ReceiptItemErrorCode.INVALID_TRIP_STATUS);
+        }
+    }
+
+    private void validateTripMember(Long tripId, Long userId) {
+        boolean isActiveMember = tripMemberRepository.existsByTrip_IdAndUser_IdAndStatus(tripId, userId, TripMemberStatus.ACTIVE);
+
+        if (!isActiveMember) {
+            throw new ReceiptItemException(ReceiptItemErrorCode.TRIP_MEMBER_REQUIRED);
+        }
+    }
+
+    private void validateReceiptStatus(Receipt receipt) {
+        if (receipt.getStatus() == ReceiptStatus.DELETED) {
+            throw new ReceiptItemException(ReceiptItemErrorCode.RECEIPT_DELETED);
+        }
+    }
+}

--- a/src/main/java/AIFinance/demo/trip/repository/TripMemberRepository.java
+++ b/src/main/java/AIFinance/demo/trip/repository/TripMemberRepository.java
@@ -1,0 +1,10 @@
+package AIFinance.demo.trip.repository;
+
+import AIFinance.demo.trip.entity.TripMember;
+import AIFinance.demo.trip.entity.enums.TripMemberStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TripMemberRepository extends JpaRepository<TripMember, Long> {
+    // 여행방 Id, 유저 Id, 멤버 상태 확인
+    boolean existsByTrip_IdAndUser_IdAndStatus(Long tripId, Long userId, TripMemberStatus status);
+}

--- a/src/main/java/AIFinance/demo/trip/repository/TripRepository.java
+++ b/src/main/java/AIFinance/demo/trip/repository/TripRepository.java
@@ -1,0 +1,8 @@
+package AIFinance.demo.trip.repository;
+
+import AIFinance.demo.trip.entity.Trip;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TripRepository extends JpaRepository<Trip, Long> {
+
+}


### PR DESCRIPTION
## 관련 이슈
Closes #9

## 작업 내용
<!-- 이 PR에서 진행한 작업을 간단히 설명해주세요. -->
- 영수증에 배달비·봉사료 등 추가 비용 항목을 등록하는 API를 구현했습니다.
- 여행 참여 권한과 여행·영수증 상태를 검증하도록 구현했습니다.

## 주요 변경 사항
<!-- 주요 변경 사항을 작성해주세요. -->
- 추가 비용 등록 요청·응답 DTO 및 입력값 Validation 추가
- Trip, TripMember, Receipt, ReceiptItem Repository 추가
- 추가 비용 등록 Service 및 Controller 구현
- 추가 비용 성공·예외 코드와 도메인 예외 추가
- 추가 비용을 `ReceiptItem`으로 저장하고 `ADDITIONAL_COST`로 구분
- Bean Validation 의존성 추가

## 동작 흐름
<!-- 변경된 기능의 동작 흐름이나 처리 과정을 작성해주세요. 해당하지 않는 경우 삭제해주세요. -->
- 요청한 여행방의 존재 여부와 `ACTIVE` 상태를 확인합니다.
- 요청 사용자가 해당 여행방의 활성 참여자인지 확인합니다.
- 요청한 영수증이 해당 여행방에 속하는지 확인합니다.
- 삭제된 영수증인지 확인합니다.
- 배달비·봉사료를 `ReceiptItem`으로 생성하고 저장합니다.
- 저장된 추가 비용 항목을 공통 응답 형식으로 반환합니다.

## 응답 예시
<!-- API 응답이나 실행 결과가 있다면 작성해주세요. 해당하지 않는 경우 삭제해주세요. -->

```json
{
  "isSuccess": true,
  "code": "ADDITIONAL_COST_CREATED",
  "message": "추가 비용 항목이 등록되었습니다.",
  "result": {
    "itemId": 101,
    "receiptId": 10,
    "itemName": "배달비·봉사료",
    "quantity": 1,
    "originalAmount": 3000,
    "settlementAmount": 3000
  }
}
```

## AI 사용 여부
- [x] 사용함
- [ ] 사용하지 않음

### 사용한 AI 기능
<!-- AI를 사용한 경우에만 작성해주세요. -->

- AI 기능/도구: ChatGPT/Codex
- 사용 범위: 기능 명세·ERD·와이어프레임 기반 API 책임 검토, 코드 구조 및 예외 처리 검토
- 생성된 코드 직접 검토 여부: [x] Yes
- AI 생성 코드를 수정했나요?: [x] Yes / [ ] No

## 팀원이 확인해야 할 것

<!-- 리뷰 시 중점적으로 확인해야 할 내용이 있다면 작성해주세요. -->
- 추가 비용을 일반 상품과 동일한 ReceiptItem으로 저장하는 구조가 적절한지 확인 부탁드립니다.
- 배달비·봉사료는 구분하지 않고 category = ADDITIONAL_COST로 저장합니다.
- 인증 구현 전이므로 현재는 X-USER-ID 헤더로 사용자를 임시 식별하며, 인증 기능 머지 후 교체가 필요합니다.
- DataSource가 아직 설정되지 않아 실제 DB 연동 및 API 통합 테스트는 진행하지 못했습니다.
