### PR TITLE
[FEAT] 추가 비용 항목 삭제 API 구현

### DIFF
--- a/src/main/java/AIFinance/demo/receipt/controller/ReceiptItemController.java
+++ b/src/main/java/AIFinance/demo/receipt/controller/ReceiptItemController.java
@@ -7,27 +7,55 @@ import AIFinance.demo.receipt.exception.code.ReceiptItemSuccessCode;
 import AIFinance.demo.receipt.service.ReceiptItemService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/trips/{tripId}/receipts/{receiptId}/items")
 public class ReceiptItemController {
+
     private final ReceiptItemService receiptItemService;
 
     @PostMapping
-    public ResponseEntity<ApiResponse<ReceiptItemResponse.CreatedAdditionalCost>> createAdditionalCost(
+    public ApiResponse<ReceiptItemResponse.CreatedAdditionalCost>
+    createAdditionalCost(
             @RequestHeader("X-USER-ID") Long userId,
             @PathVariable Long tripId,
             @PathVariable Long receiptId,
-            @Valid @RequestBody ReceiptItemRequest.CreateAdditionalCost request
-    ){
-        ReceiptItemResponse.CreatedAdditionalCost result = receiptItemService.createAdditionalCost(userId, tripId, receiptId, request);
-        ReceiptItemSuccessCode successCode = ReceiptItemSuccessCode.ADDITIONAL_COST_CREATED;
+            @Valid @RequestBody
+            ReceiptItemRequest.CreateAdditionalCost request
+    ) {
+        ReceiptItemResponse.CreatedAdditionalCost result =
+                receiptItemService.createAdditionalCost(
+                        userId,
+                        tripId,
+                        receiptId,
+                        request
+                );
 
-        return ResponseEntity
-                .status(successCode.getStatus())
-                .body(ApiResponse.onSuccess(successCode, result));
+        return ApiResponse.onSuccess(
+                ReceiptItemSuccessCode.ADDITIONAL_COST_CREATED,
+                result
+        );
+    }
+
+    @DeleteMapping("/{itemId}")
+    public ApiResponse<Void> deleteAdditionalCost(
+            @RequestHeader("X-USER-ID") Long userId,
+            @PathVariable Long tripId,
+            @PathVariable Long receiptId,
+            @PathVariable Long itemId
+    ) {
+        receiptItemService.deleteAdditionalCost(
+                userId,
+                tripId,
+                receiptId,
+                itemId
+        );
+
+        return ApiResponse.onSuccess(
+                ReceiptItemSuccessCode.ADDITIONAL_COST_DELETED,
+                null
+        );
     }
 }

--- a/src/main/java/AIFinance/demo/receipt/entity/ReceiptItem.java
+++ b/src/main/java/AIFinance/demo/receipt/entity/ReceiptItem.java
@@ -49,6 +49,8 @@ public class ReceiptItem extends BaseEntity {
     @JoinColumn(name = "remainder_member_id")
     private TripMember remainderMember;
 
+    private static final String ADDITIONAL_COST_CATEGORY = "ADDITIONAL_COST";
+
     public static ReceiptItem createAdditionalCost(
             Receipt receipt,
             String itemName,
@@ -61,9 +63,13 @@ public class ReceiptItem extends BaseEntity {
         item.unitPrice = amount;
         item.originalAmount = amount;
         item.settlementAmount = amount;
-        item.category = "ADDITIONAL_COST";
+        item.category = ADDITIONAL_COST_CATEGORY;
 
         return item;
+    }
+
+    public boolean isAdditionalCost() {
+        return ADDITIONAL_COST_CATEGORY.equals(category);
     }
 }
 

--- a/src/main/java/AIFinance/demo/receipt/exception/code/ReceiptItemErrorCode.java
+++ b/src/main/java/AIFinance/demo/receipt/exception/code/ReceiptItemErrorCode.java
@@ -36,6 +36,18 @@ public enum ReceiptItemErrorCode implements BaseErrorCode {
             HttpStatus.CONFLICT,
             "RECEIPT_DELETED",
             "삭제된 영수증에는 추가 비용을 등록할 수 없습니다."
+    ),
+
+    RECEIPT_ITEM_NOT_FOUND(
+            HttpStatus.NOT_FOUND,
+            "RECEIPT_ITEM_NOT_FOUND",
+            "해당 영수증에서 추가 비용 항목을 찾을 수 없습니다."
+    ),
+
+    NOT_ADDITIONAL_COST(
+            HttpStatus.BAD_REQUEST,
+            "NOT_ADDITIONAL_COST",
+            "추가 비용 항목만 삭제할 수 있습니다."
     );
 
     private final HttpStatus status;

--- a/src/main/java/AIFinance/demo/receipt/exception/code/ReceiptItemSuccessCode.java
+++ b/src/main/java/AIFinance/demo/receipt/exception/code/ReceiptItemSuccessCode.java
@@ -13,6 +13,12 @@ public enum ReceiptItemSuccessCode implements BaseSuccessCode {
             HttpStatus.CREATED,
             "ADDITIONAL_COST_CREATED",
             "추가 비용 항목이 등록되었습니다."
+    ),
+
+    ADDITIONAL_COST_DELETED(
+            HttpStatus.OK,
+            "ADDITIONAL_COST_DELETED",
+            "추가 비용 항목이 삭제되었습니다."
     );
 
     private final HttpStatus status;

--- a/src/main/java/AIFinance/demo/receipt/repository/ReceiptItemRepository.java
+++ b/src/main/java/AIFinance/demo/receipt/repository/ReceiptItemRepository.java
@@ -3,7 +3,11 @@ package AIFinance.demo.receipt.repository;
 import AIFinance.demo.receipt.entity.ReceiptItem;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 
 public interface ReceiptItemRepository extends JpaRepository<ReceiptItem, Long> {
+
+    Optional<ReceiptItem> findByIdAndReceipt_Id(Long itemId, Long receiptId);
 
 }

--- a/src/main/java/AIFinance/demo/receipt/service/ReceiptItemService.java
+++ b/src/main/java/AIFinance/demo/receipt/service/ReceiptItemService.java
@@ -22,6 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class ReceiptItemService {
+
     private final TripRepository tripRepository;
     private final TripMemberRepository tripMemberRepository;
     private final ReceiptRepository receiptRepository;
@@ -29,22 +30,49 @@ public class ReceiptItemService {
 
     @Transactional
     public ReceiptItemResponse.CreatedAdditionalCost createAdditionalCost(Long userId, Long tripId, Long receiptId, ReceiptItemRequest.CreateAdditionalCost request) {
-        Trip trip = tripRepository.findById(tripId)
-                .orElseThrow(() -> new ReceiptItemException(ReceiptItemErrorCode.TRIP_NOT_FOUND));
+        Trip trip = getTrip(tripId);
 
         validateTripStatus(trip);
         validateTripMember(tripId, userId);
 
-        Receipt receipt = receiptRepository.findByIdAndTrip_Id(receiptId, tripId)
-                .orElseThrow(() -> new ReceiptItemException(ReceiptItemErrorCode.RECEIPT_NOT_FOUND));
+        Receipt receipt = getReceipt(receiptId, tripId);
 
         validateReceiptStatus(receipt);
 
         ReceiptItem receiptItem = ReceiptItem.createAdditionalCost(receipt, request.itemName(), request.amount());
+
         ReceiptItem savedItem = receiptItemRepository.save(receiptItem);
 
         return ReceiptItemResponse.CreatedAdditionalCost.from(savedItem);
+    }
 
+    @Transactional
+    public void deleteAdditionalCost(Long userId, Long tripId, Long receiptId, Long itemId) {
+        Trip trip = getTrip(tripId);
+
+        validateTripStatus(trip);
+        validateTripMember(tripId, userId);
+
+        Receipt receipt = getReceipt(receiptId, tripId);
+
+        validateReceiptStatus(receipt);
+
+        ReceiptItem receiptItem = receiptItemRepository.findByIdAndReceipt_Id(itemId, receiptId)
+                        .orElseThrow(() -> new ReceiptItemException(ReceiptItemErrorCode.RECEIPT_ITEM_NOT_FOUND));
+
+        validateAdditionalCost(receiptItem);
+
+        receiptItemRepository.delete(receiptItem);
+    }
+
+    private Trip getTrip(Long tripId) {
+        return tripRepository.findById(tripId)
+                .orElseThrow(() -> new ReceiptItemException(ReceiptItemErrorCode.TRIP_NOT_FOUND));
+    }
+
+    private Receipt getReceipt(Long receiptId, Long tripId) {
+        return receiptRepository.findByIdAndTrip_Id(receiptId, tripId)
+                .orElseThrow(() -> new ReceiptItemException(ReceiptItemErrorCode.RECEIPT_NOT_FOUND));
     }
 
     private void validateTripStatus(Trip trip) {
@@ -64,6 +92,14 @@ public class ReceiptItemService {
     private void validateReceiptStatus(Receipt receipt) {
         if (receipt.getStatus() == ReceiptStatus.DELETED) {
             throw new ReceiptItemException(ReceiptItemErrorCode.RECEIPT_DELETED);
+        }
+    }
+
+    private void validateAdditionalCost(ReceiptItem receiptItem) {
+        if (!receiptItem.isAdditionalCost()) {
+            throw new ReceiptItemException(
+                    ReceiptItemErrorCode.NOT_ADDITIONAL_COST
+            );
         }
     }
 }


### PR DESCRIPTION
## 관련 이슈
Closes #12

## 작업 내용
<!-- 이 PR에서 진행한 작업을 간단히 설명해주세요. -->
- 영수증에 등록된 배달비·봉사료 등 추가 비용 항목을 삭제하는 API를 구현했습니다.
- 일반 상품이 추가 비용 삭제 API를 통해 삭제되지 않도록 검증 로직을 추가했습니다.

## 주요 변경 사항
<!-- 주요 변경 사항을 작성해주세요. -->
- 추가 비용 항목 삭제 Controller 및 Service 로직 구현
- 영수증과 상품 항목의 소속 관계를 확인하는 Repository 조회 메서드 추가
- 추가 비용 삭제 성공 코드 및 상품 조회·유형 오류 코드 추가
- `ReceiptItem`에 추가 비용 항목 여부를 판단하는 메서드 추가
- 기존 등록·삭제 로직의 공통 여행방 및 영수증 조회 로직 정리

## 동작 흐름
<!-- 변경된 기능의 동작 흐름이나 처리 과정을 작성해주세요. 해당하지 않는 경우 삭제해주세요. -->
- 요청한 여행방의 존재 여부와 `ACTIVE` 상태를 확인합니다.
- 요청 사용자가 해당 여행방의 활성 참여자인지 확인합니다.
- 요청한 영수증이 해당 여행방에 속하고 삭제되지 않았는지 확인합니다.
- 요청한 항목이 해당 영수증에 속하는지 확인합니다.
- 대상 항목의 category가 `ADDITIONAL_COST`인지 확인합니다.
- 모든 검증을 통과하면 해당 추가 비용 항목을 삭제합니다.

## 응답 예시
<!-- API 응답이나 실행 결과가 있다면 작성해주세요. 해당하지 않는 경우 삭제해주세요. -->

```json
{
  "isSuccess": true,
  "code": "ADDITIONAL_COST_DELETED",
  "message": "추가 비용 항목이 삭제되었습니다.",
  "result": null
}
```

## AI 사용 여부
- [ ] 사용함
- [ ] 사용하지 않음

### 사용한 AI 기능
<!-- AI를 사용한 경우에만 작성해주세요. -->

- AI 기능/도구:
- 사용 범위: 
- 생성된 코드 직접 검토 여부: [ ] Yes
- AI 생성 코드를 수정했나요?: [ ] Yes / [ ] No

## 팀원이 확인해야 할 것

<!-- 리뷰 시 중점적으로 확인해야 할 내용이 있다면 작성해주세요. -->

- 일반 상품은 이 API를 통해 삭제할 수 없습니다.
- 현재 인증 기능이 없어 X-USER-ID 헤더로 사용자를 임시 식별합니다.
- 향후 SPLIT의 ItemShare가 구현되면 추가 비용 삭제 시 연결된 부담 정보 처리 정책을 반영해야 합니다.