### PR TITLE
[FIX] 요청값 검증 예외 400 응답 처리

### DIFF
--- a/src/main/java/AIFinance/demo/global/apiPayload/handler/GeneralExceptionAdvice.java
+++ b/src/main/java/AIFinance/demo/global/apiPayload/handler/GeneralExceptionAdvice.java
@@ -5,9 +5,17 @@ import AIFinance.demo.global.apiPayload.code.BaseErrorCode;
 import AIFinance.demo.global.apiPayload.code.GeneralErrorCode;
 import AIFinance.demo.global.apiPayload.exception.GeneralException;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingRequestHeaderException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.HandlerMethodValidationException;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @RestControllerAdvice
 public class GeneralExceptionAdvice {
 
@@ -25,18 +33,42 @@ public class GeneralExceptionAdvice {
                 );
     }
 
-    // 그 외의 정의되지 않은 모든 예외 처리
-    @ExceptionHandler(Exception.class)
-    public ResponseEntity<ApiResponse<String>> handleException(
+    // 400 에러 구분 
+    @ExceptionHandler({
+            MethodArgumentNotValidException.class,
+            HandlerMethodValidationException.class,
+            HttpMessageNotReadableException.class,
+            MethodArgumentTypeMismatchException.class,
+            MissingRequestHeaderException.class,
+            MissingServletRequestParameterException.class
+    })
+    public ResponseEntity<ApiResponse<Void>> handleBadRequest(
             Exception ex
     ) {
-        
-        BaseErrorCode code = GeneralErrorCode.INTERNAL_SERVER_ERROR;
-        return ResponseEntity.status(code.getStatus())
-                .body(ApiResponse.onFailure(
+        BaseErrorCode code = GeneralErrorCode.BAD_REQUEST;
+
+        return ResponseEntity
+                .status(code.getStatus())
+                .body(
+                        ApiResponse.onFailure(
                                 code,
-                                ex.getMessage()
+                                null
                         )
                 );
+    }
+
+
+    // 그 외의 정의되지 않은 모든 예외 처리
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<Void>> handleUnexpectedException(
+            Exception ex
+    ) {
+        log.error("예상치 못한 서버 오류가 발생했습니다. ", ex);
+
+        BaseErrorCode code = GeneralErrorCode.INTERNAL_SERVER_ERROR;
+
+        return ResponseEntity
+                .status(code.getStatus())
+                .body(ApiResponse.onFailure(code, null));
     }
 }


### PR DESCRIPTION
## 관련 이슈
Closes #16

## 작업 내용
<!-- 이 PR에서 진행한 작업을 간단히 설명해주세요. -->
- 요청값 검증 및 요청 형식 관련 예외를 400 Bad Request로 처리하도록 전역 예외 처리를 수정했습니다.
- 예상하지 못한 서버 오류의 상세 내용을 서버 로그에 기록하도록 수정했습니다.

## 주요 변경 사항
<!-- 주요 변경 사항을 작성해주세요. -->
- 요청값 검증 실패 예외에 대한 공통 400 응답 처리 추가
- 잘못된 JSON, 타입 불일치, 필수 헤더·파라미터 누락 예외 처리 추가
- 예상하지 못한 예외 발생 시 log.error로 스택 트레이스 기록
- 500 응답에 내부 예외 메시지가 노출되지 않도록 수정

## 동작 흐름
<!-- 변경된 기능의 동작 흐름이나 처리 과정을 작성해주세요. 해당하지 않는 경우 삭제해주세요. -->
- 요청값 또는 요청 형식에 문제가 있으면 COMMON_BAD_REQUEST와 함께 400 Bad Request를 반환합니다.
- 도메인 예외는 기존과 동일하게 각 예외 코드에 지정된 HTTP 상태를 반환합니다.
- 처리되지 않은 예외는 서버에 상세 로그를 남기고 공통 500 Internal Server Error 응답을 반환합니다.

## 응답 예시
<!-- API 응답이나 실행 결과가 있다면 작성해주세요. 해당하지 않는 경우 삭제해주세요. -->

```json
{
  "isSuccess": false,
  "code": "COMMON_BAD_REQUEST",
  "message": "잘못된 요청입니다.",
  "result": null
}
```

## AI 사용 여부
- [ ] 사용함
- [ ] 사용하지 않음

### 사용한 AI 기능
<!-- AI를 사용한 경우에만 작성해주세요. -->

- AI 기능/도구:
- 사용 범위:
- 생성된 코드 직접 검토 여부: [ ] Yes
- AI 생성 코드를 수정했나요?: [ ] Yes / [ ] No

## 팀원이 확인해야 할 것

<!-- 리뷰 시 중점적으로 확인해야 할 내용이 있다면 작성해주세요. -->

-
