### PR TITLE
[FEAT] 정산 및 송금 엔티티 구현

### DIFF
--- a/src/main/java/AIFinance/demo/settlement/entity/Settlement.java
+++ b/src/main/java/AIFinance/demo/settlement/entity/Settlement.java
@@ -1,0 +1,71 @@
+package AIFinance.demo.settlement.entity;
+
+import AIFinance.demo.global.entity.BaseEntity;
+import AIFinance.demo.settlement.entity.enums.SettlementStatus;
+import AIFinance.demo.trip.entity.Trip;
+import AIFinance.demo.trip.entity.TripMember;
+import jakarta.persistence.*;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Builder
+@Getter
+@Table(
+        name = "settlements",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_settlements_trip",
+                        columnNames = "trip_id"
+                )
+        }
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class Settlement extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "settlement_id")
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "trip_id", nullable = false)
+    private Trip trip;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "confirmed_by_member_id", nullable = false)
+    private TripMember confirmedByMember;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    @Builder.Default
+    private SettlementStatus status = SettlementStatus.CONFIRMED;
+
+    @Column(name = "total_amount", nullable = false)
+    private Long totalAmount;
+
+    @Column(name = "confirmed_at", nullable = false)
+    private LocalDateTime confirmedAt;
+
+    @Column(name = "completed_at")
+    private LocalDateTime completedAt;
+
+    public static Settlement create(Trip trip, TripMember confirmedByMember, Long totalAmount) {
+        return Settlement.builder()
+                .trip(trip)
+                .confirmedByMember(confirmedByMember)
+                .totalAmount(totalAmount)
+                .status(SettlementStatus.CONFIRMED)
+                .confirmedAt(LocalDateTime.now())
+                .build();
+    }
+
+    public void complete() {
+        this.status = SettlementStatus.COMPLETED;
+        this.completedAt = LocalDateTime.now();
+    }
+
+}

--- a/src/main/java/AIFinance/demo/settlement/entity/SettlementTransfer.java
+++ b/src/main/java/AIFinance/demo/settlement/entity/SettlementTransfer.java
@@ -1,0 +1,69 @@
+package AIFinance.demo.settlement.entity;
+
+import AIFinance.demo.global.entity.BaseEntity;
+import AIFinance.demo.settlement.entity.enums.SettlementTransferStatus;
+import AIFinance.demo.trip.entity.TripMember;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Builder
+@Getter
+@Table(name = "settlement_transfers")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class SettlementTransfer extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "transfer_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "settlement_id", nullable = false)
+    private Settlement settlement;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "sender_member_id", nullable = false)
+    private TripMember senderMember;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "receiver_member_id", nullable = false)
+    private TripMember receiverMember;
+
+    @Column(name = "amount", nullable = false)
+    private Long amount;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    @Builder.Default
+    private SettlementTransferStatus status = SettlementTransferStatus.PENDING;
+
+    @Column(name = "sent_at")
+    private LocalDateTime sentAt;
+
+    @Column(name = "confirmed_at")
+    private LocalDateTime confirmedAt;
+
+    public static SettlementTransfer create(Settlement settlement, TripMember senderMember, TripMember receiverMember, Long amount) {
+        return SettlementTransfer.builder()
+                .settlement(settlement)
+                .senderMember(senderMember)
+                .receiverMember(receiverMember)
+                .amount(amount)
+                .status(SettlementTransferStatus.PENDING)
+                .build();
+    }
+
+    public void markSent() {
+        this.status = SettlementTransferStatus.SENT;
+        this.sentAt = LocalDateTime.now();
+    }
+
+    public void confirm() {
+        this.status =  SettlementTransferStatus.COMPLETED;
+        this.confirmedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/AIFinance/demo/settlement/entity/enums/SettlementStatus.java
+++ b/src/main/java/AIFinance/demo/settlement/entity/enums/SettlementStatus.java
@@ -1,0 +1,6 @@
+package AIFinance.demo.settlement.entity.enums;
+
+public enum SettlementStatus {
+    CONFIRMED,
+    COMPLETED
+}

--- a/src/main/java/AIFinance/demo/settlement/entity/enums/SettlementTransferStatus.java
+++ b/src/main/java/AIFinance/demo/settlement/entity/enums/SettlementTransferStatus.java
@@ -1,0 +1,7 @@
+package AIFinance.demo.settlement.entity.enums;
+
+public enum SettlementTransferStatus {
+    PENDING,
+    SENT,
+    COMPLETED
+}

--- a/src/main/java/AIFinance/demo/settlement/repository/SettlementRepository.java
+++ b/src/main/java/AIFinance/demo/settlement/repository/SettlementRepository.java
@@ -1,0 +1,7 @@
+package AIFinance.demo.settlement.repository;
+
+import AIFinance.demo.settlement.entity.Settlement;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SettlementRepository extends JpaRepository<Settlement, Long> {
+}

--- a/src/main/java/AIFinance/demo/settlement/repository/SettlementTransferRepository.java
+++ b/src/main/java/AIFinance/demo/settlement/repository/SettlementTransferRepository.java
@@ -1,0 +1,7 @@
+package AIFinance.demo.settlement.repository;
+
+import AIFinance.demo.settlement.entity.SettlementTransfer;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SettlementTransferRepository extends JpaRepository<SettlementTransfer, Long> {
+}


### PR DESCRIPTION
## 관련 이슈
Closes #18

## 작업 내용
<!-- 이 PR에서 진행한 작업을 간단히 설명해주세요. -->
- 정산 확정 결과와 참여자 간 송금 관계를 저장하기 위한 정산 도메인 엔티티를 구현했습니다.
- 정산 및 송금 상태를 관리하기 위한 Enum과 Repository를 추가했습니다. 

## 주요 변경 사항
<!-- 주요 변경 사항을 작성해주세요. -->
- Settlement 엔티티 구현
- SettlementTransfer 엔티티 구현
- SettlementStatus, SettlementTransferStatus Enum 구현
- SettlementRepository, SettlementTransferRepository 구현
- 여행방과 정산 간 1:1 관계 및 여행당 하나의 정산만 생성되도록 UNIQUE 제약조건 설정
- 정산 확정·완료 시간과 송금 완료·입금 확인 시간 필드 적용
- 정산 및 송금 상태 변경 메서드 구현

## 동작 흐름
<!-- 변경된 기능의 동작 흐름이나 처리 과정을 작성해주세요. 해당하지 않는 경우 삭제해주세요. -->
- 정산 확정 시 Settlement이 CONFIRMED 상태로 생성됩니다.
- 참여자 간 송금 관계는 SettlementTransfer로 생성되며 초기 상태는 PENDING입니다.
- 송금 완료 표시 시 송금 상태가 SENT로 변경되고 sentAt이 기록됩니다.
- 수취인이 입금을 확인하면 송금 상태가 COMPLETED로 변경되고 confirmedAt이 기록됩니다.
- 정산 종료 시 정산 상태가 COMPLETED로 변경되고 completedAt이 기록됩니다.

## AI 사용 여부
- [ ] 사용함
- [ ] 사용하지 않음

### 사용한 AI 기능
<!-- AI를 사용한 경우에만 작성해주세요. -->

- AI 기능/도구:
- 사용 범위:
- 생성된 코드 직접 검토 여부: [ ] Yes
- AI 생성 코드를 수정했나요?: [ ] Yes / [ ] No

## 팀원이 확인해야 할 것

<!-- 리뷰 시 중점적으로 확인해야 할 내용이 있다면 작성해주세요. -->

- Trip과 Settlement의 1:1 관계 및 UNIQUE 제약조건이 적절한지 확인 부탁드립니다.
