### PR TITLE
[FEAT] AUTH API 구현 (회원가입/로그인/토큰재발급/로그아웃/중복확인/내정보)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,12 @@ dependencies {
 	testAnnotationProcessor 'org.projectlombok:lombok'
 
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+	implementation 'io.jsonwebtoken:jjwt-api:0.13.0'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.13.0'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.13.0'
+
+	runtimeOnly 'com.mysql:mysql-connector-j'
 }
 
 tasks.named('test') {

--- a/src/main/java/AIFinance/demo/auth/controller/AuthController.java
+++ b/src/main/java/AIFinance/demo/auth/controller/AuthController.java
@@ -1,0 +1,121 @@
+package AIFinance.demo.auth.controller;
+
+import AIFinance.demo.auth.dto.*;
+import AIFinance.demo.auth.exception.AuthErrorCode;
+import AIFinance.demo.auth.service.AuthService;
+import AIFinance.demo.global.apiPayload.ApiResponse;
+import AIFinance.demo.global.apiPayload.code.GeneralSuccessCode;
+import AIFinance.demo.global.apiPayload.exception.GeneralException;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.Duration;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/auth")
+public class AuthController {
+
+    private static final String REFRESH_TOKEN_COOKIE_NAME = "refreshToken";
+    private static final String REFRESH_TOKEN_COOKIE_PATH = "/api/v1/auth";
+    private static final Duration REFRESH_TOKEN_MAX_AGE = Duration.ofDays(14);
+
+    private final AuthService authService;
+
+    @PostMapping("/signup")
+    public ResponseEntity<ApiResponse<SignupResponse>> signup(
+            @Valid @RequestBody SignupRequest request
+    ) {
+        SignupResponse response = authService.signup(request);
+
+        return ResponseEntity.status(GeneralSuccessCode.CREATED.getStatus())
+                .body(ApiResponse.onSuccess(GeneralSuccessCode.CREATED, response));
+    }
+
+    @PostMapping("/login")
+    public ApiResponse<LoginResponse> login(
+            @Valid @RequestBody LoginRequest request,
+            HttpServletResponse httpResponse
+    ) {
+        LoginResult result = authService.login(request);
+        addRefreshTokenCookie(httpResponse, result.refreshToken());
+
+        return ApiResponse.onSuccess(GeneralSuccessCode.OK, result.response());
+    }
+
+    @GetMapping("/check")
+    public ApiResponse<DuplicateCheckResponse> checkDuplicate(
+            @RequestParam String type,
+            @RequestParam String value
+    ) {
+        DuplicateCheckResponse response = authService.checkDuplicate(type, value);
+
+        return ApiResponse.onSuccess(GeneralSuccessCode.OK, response);
+    }
+
+    @PostMapping("/refresh")
+    public ApiResponse<TokenReissueResponse> reissue(
+            @CookieValue(REFRESH_TOKEN_COOKIE_NAME) String refreshToken,
+            HttpServletResponse httpResponse
+    ) {
+        TokenReissueResult result = authService.reissue(refreshToken);
+        addRefreshTokenCookie(httpResponse, result.refreshToken());
+
+        return ApiResponse.onSuccess(GeneralSuccessCode.OK, result.response());
+    }
+
+    @PostMapping("/logout")
+    public ApiResponse<Void> logout(
+            @CookieValue(value = REFRESH_TOKEN_COOKIE_NAME, required = false) String refreshToken,
+            HttpServletResponse httpResponse
+    ) {
+        authService.logout(refreshToken);
+        expireRefreshTokenCookie(httpResponse);
+
+        return ApiResponse.onSuccess(GeneralSuccessCode.OK, null);
+    }
+
+    @GetMapping("/me")
+    public ApiResponse<MeResponse> getMe() {
+        Long userId = currentUserId();
+        MeResponse response = authService.getMe(userId);
+
+        return ApiResponse.onSuccess(GeneralSuccessCode.OK, response);
+    }
+
+    private Long currentUserId() {
+        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        if (!(principal instanceof Long userId)) {
+            throw new GeneralException(AuthErrorCode.USER_NOT_FOUND);
+        }
+        return userId;
+    }
+
+    private void addRefreshTokenCookie(HttpServletResponse response, String refreshToken) {
+        ResponseCookie cookie = ResponseCookie.from(REFRESH_TOKEN_COOKIE_NAME, refreshToken)
+                .httpOnly(true)
+                .secure(true)
+                .sameSite("None")
+                .path(REFRESH_TOKEN_COOKIE_PATH)
+                .maxAge(REFRESH_TOKEN_MAX_AGE)
+                .build();
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+    }
+
+    private void expireRefreshTokenCookie(HttpServletResponse response) {
+        ResponseCookie cookie = ResponseCookie.from(REFRESH_TOKEN_COOKIE_NAME, "")
+                .httpOnly(true)
+                .secure(true)
+                .sameSite("None")
+                .path(REFRESH_TOKEN_COOKIE_PATH)
+                .maxAge(0)
+                .build();
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+    }
+}

--- a/src/main/java/AIFinance/demo/auth/dto/DuplicateCheckResponse.java
+++ b/src/main/java/AIFinance/demo/auth/dto/DuplicateCheckResponse.java
@@ -1,0 +1,6 @@
+package AIFinance.demo.auth.dto;
+
+public record DuplicateCheckResponse(
+        boolean available
+) {
+}

--- a/src/main/java/AIFinance/demo/auth/dto/LoginRequest.java
+++ b/src/main/java/AIFinance/demo/auth/dto/LoginRequest.java
@@ -1,0 +1,12 @@
+package AIFinance.demo.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record LoginRequest(
+        @NotBlank
+        String email,
+
+        @NotBlank
+        String password
+) {
+}

--- a/src/main/java/AIFinance/demo/auth/dto/LoginResponse.java
+++ b/src/main/java/AIFinance/demo/auth/dto/LoginResponse.java
@@ -1,0 +1,8 @@
+package AIFinance.demo.auth.dto;
+
+public record LoginResponse(
+        String accessToken,
+        Long userId,
+        String nickname
+) {
+}

--- a/src/main/java/AIFinance/demo/auth/dto/LoginResult.java
+++ b/src/main/java/AIFinance/demo/auth/dto/LoginResult.java
@@ -1,0 +1,7 @@
+package AIFinance.demo.auth.dto;
+
+public record LoginResult(
+        LoginResponse response,
+        String refreshToken
+) {
+}

--- a/src/main/java/AIFinance/demo/auth/dto/MeResponse.java
+++ b/src/main/java/AIFinance/demo/auth/dto/MeResponse.java
@@ -1,0 +1,8 @@
+package AIFinance.demo.auth.dto;
+
+public record MeResponse(
+        Long userId,
+        String email,
+        String nickname
+) {
+}

--- a/src/main/java/AIFinance/demo/auth/dto/SignupRequest.java
+++ b/src/main/java/AIFinance/demo/auth/dto/SignupRequest.java
@@ -1,0 +1,21 @@
+package AIFinance.demo.auth.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record SignupRequest(
+        @Email
+        @NotBlank
+        String email,
+
+        @Pattern(
+                regexp = "^(?=.*[A-Za-z])(?=.*\\d).{8,}$",
+                message = "비밀번호는 영문과 숫자를 포함하여 8자 이상이어야 합니다."
+        )
+        String password,
+
+        @NotBlank
+        String nickname
+) {
+}

--- a/src/main/java/AIFinance/demo/auth/dto/SignupResponse.java
+++ b/src/main/java/AIFinance/demo/auth/dto/SignupResponse.java
@@ -1,0 +1,8 @@
+package AIFinance.demo.auth.dto;
+
+public record SignupResponse(
+        Long userId,
+        String email,
+        String nickname
+) {
+}

--- a/src/main/java/AIFinance/demo/auth/dto/TokenReissueResponse.java
+++ b/src/main/java/AIFinance/demo/auth/dto/TokenReissueResponse.java
@@ -1,0 +1,6 @@
+package AIFinance.demo.auth.dto;
+
+public record TokenReissueResponse(
+        String accessToken
+) {
+}

--- a/src/main/java/AIFinance/demo/auth/dto/TokenReissueResult.java
+++ b/src/main/java/AIFinance/demo/auth/dto/TokenReissueResult.java
@@ -1,0 +1,7 @@
+package AIFinance.demo.auth.dto;
+
+public record TokenReissueResult(
+        TokenReissueResponse response,
+        String refreshToken
+) {
+}

--- a/src/main/java/AIFinance/demo/auth/entity/RefreshToken.java
+++ b/src/main/java/AIFinance/demo/auth/entity/RefreshToken.java
@@ -1,0 +1,41 @@
+package AIFinance.demo.auth.entity;
+
+import AIFinance.demo.global.entity.BaseEntity;
+import AIFinance.demo.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Builder
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(name = "refresh_tokens")
+public class RefreshToken extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "refresh_token_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "token", nullable = false, unique = true, length = 255)
+    private String token;
+
+    @Column(name = "expires_at", nullable = false)
+    private LocalDateTime expiresAt;
+
+    @Column(name = "revoked", nullable = false)
+    @Builder.Default
+    private boolean revoked = false;
+
+    public void revoke() {
+        this.revoked = true;
+    }
+
+}

--- a/src/main/java/AIFinance/demo/auth/exception/AuthErrorCode.java
+++ b/src/main/java/AIFinance/demo/auth/exception/AuthErrorCode.java
@@ -1,0 +1,30 @@
+package AIFinance.demo.auth.exception;
+
+import AIFinance.demo.global.apiPayload.code.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum AuthErrorCode implements BaseErrorCode {
+    EMAIL_DUPLICATE(HttpStatus.CONFLICT,
+            "AUTH_EMAIL_DUPLICATE",
+            "이미 사용 중인 이메일입니다."),
+    NICKNAME_DUPLICATE(HttpStatus.CONFLICT,
+            "AUTH_NICKNAME_DUPLICATE",
+            "이미 사용 중인 닉네임입니다."),
+    INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED,
+            "AUTH_INVALID_CREDENTIALS",
+            "이메일 또는 비밀번호가 올바르지 않습니다."),
+    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED,
+            "AUTH_INVALID_REFRESH_TOKEN",
+            "유효하지 않은 리프레시 토큰입니다."),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND,
+            "AUTH_USER_NOT_FOUND",
+            "사용자를 찾을 수 없습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/AIFinance/demo/auth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/AIFinance/demo/auth/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,49 @@
+package AIFinance.demo.auth.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    private final JwtProvider jwtProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                     HttpServletResponse response,
+                                     FilterChain filterChain) throws ServletException, IOException {
+        String token = resolveToken(request);
+
+        if (StringUtils.hasText(token) && jwtProvider.validateToken(token)) {
+            Long userId = jwtProvider.getUserId(token);
+            UsernamePasswordAuthenticationToken authentication =
+                    new UsernamePasswordAuthenticationToken(userId, null, List.of());
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String header = request.getHeader(AUTHORIZATION_HEADER);
+        if (StringUtils.hasText(header) && header.startsWith(BEARER_PREFIX)) {
+            return header.substring(BEARER_PREFIX.length());
+        }
+        return null;
+    }
+}

--- a/src/main/java/AIFinance/demo/auth/jwt/JwtProvider.java
+++ b/src/main/java/AIFinance/demo/auth/jwt/JwtProvider.java
@@ -1,0 +1,93 @@
+package AIFinance.demo.auth.jwt;
+
+import AIFinance.demo.auth.exception.AuthErrorCode;
+import AIFinance.demo.global.apiPayload.exception.GeneralException;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+@Component
+public class JwtProvider {
+
+    @Value("${jwt.secret}")
+    private String secret;
+
+    @Value("${jwt.access-expiration-ms}")
+    private long accessExpirationMs;
+
+    @Value("${jwt.refresh-expiration-ms}")
+    private long refreshExpirationMs;
+
+    private SecretKey key;
+
+    @PostConstruct
+    void init() {
+        this.key = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+    }
+
+    public String generateAccessToken(Long userId) {
+        return generateToken(userId, accessExpirationMs);
+    }
+
+    public String generateRefreshToken(Long userId) {
+        return generateToken(userId, refreshExpirationMs);
+    }
+
+    public Long getUserId(String token) {
+        try {
+            Claims claims = Jwts.parser()
+                    .verifyWith(key)
+                    .build()
+                    .parseSignedClaims(token)
+                    .getPayload();
+            return Long.valueOf(claims.getSubject());
+        } catch (JwtException | IllegalArgumentException e) {
+            throw new GeneralException(AuthErrorCode.INVALID_REFRESH_TOKEN);
+        }
+    }
+
+    public Date getExpiration(String token) {
+        try {
+            Claims claims = Jwts.parser()
+                    .verifyWith(key)
+                    .build()
+                    .parseSignedClaims(token)
+                    .getPayload();
+            return claims.getExpiration();
+        } catch (JwtException | IllegalArgumentException e) {
+            throw new GeneralException(AuthErrorCode.INVALID_REFRESH_TOKEN);
+        }
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parser()
+                    .verifyWith(key)
+                    .build()
+                    .parseSignedClaims(token);
+            return true;
+        } catch (JwtException | IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    private String generateToken(Long userId, long expirationMs) {
+        Date now = new Date();
+        Date expiry = new Date(now.getTime() + expirationMs);
+
+        return Jwts.builder()
+                .subject(String.valueOf(userId))
+                .issuedAt(now)
+                .expiration(expiry)
+                .signWith(key)
+                .compact();
+    }
+}

--- a/src/main/java/AIFinance/demo/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/AIFinance/demo/auth/repository/RefreshTokenRepository.java
@@ -1,0 +1,14 @@
+package AIFinance.demo.auth.repository;
+
+import AIFinance.demo.auth.entity.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+
+    Optional<RefreshToken> findByToken(String token);
+
+    void deleteAllByUser_Id(Long userId);
+
+}

--- a/src/main/java/AIFinance/demo/auth/service/AuthService.java
+++ b/src/main/java/AIFinance/demo/auth/service/AuthService.java
@@ -1,0 +1,141 @@
+package AIFinance.demo.auth.service;
+
+import AIFinance.demo.auth.dto.*;
+import AIFinance.demo.auth.entity.RefreshToken;
+import AIFinance.demo.auth.exception.AuthErrorCode;
+import AIFinance.demo.auth.jwt.JwtProvider;
+import AIFinance.demo.auth.repository.RefreshTokenRepository;
+import AIFinance.demo.global.apiPayload.code.GeneralErrorCode;
+import AIFinance.demo.global.apiPayload.exception.GeneralException;
+import AIFinance.demo.user.entity.User;
+import AIFinance.demo.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.HexFormat;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AuthService {
+
+    private final UserRepository userRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final JwtProvider jwtProvider;
+    private final PasswordEncoder passwordEncoder;
+
+    @Transactional
+    public SignupResponse signup(SignupRequest request) {
+        if (userRepository.existsByEmail(request.email())) {
+            throw new GeneralException(AuthErrorCode.EMAIL_DUPLICATE);
+        }
+        if (userRepository.existsByNickname(request.nickname())) {
+            throw new GeneralException(AuthErrorCode.NICKNAME_DUPLICATE);
+        }
+
+        User user = User.builder()
+                .email(request.email())
+                .password(passwordEncoder.encode(request.password()))
+                .nickname(request.nickname())
+                .build();
+        userRepository.save(user);
+
+        return new SignupResponse(user.getId(), user.getEmail(), user.getNickname());
+    }
+
+    @Transactional
+    public LoginResult login(LoginRequest request) {
+        User user = userRepository.findByEmail(request.email())
+                .orElseThrow(() -> new GeneralException(AuthErrorCode.INVALID_CREDENTIALS));
+
+        if (!passwordEncoder.matches(request.password(), user.getPassword())) {
+            throw new GeneralException(AuthErrorCode.INVALID_CREDENTIALS);
+        }
+
+        String accessToken = jwtProvider.generateAccessToken(user.getId());
+        String rawRefreshToken = jwtProvider.generateRefreshToken(user.getId());
+        saveRefreshToken(user, rawRefreshToken);
+
+        LoginResponse response = new LoginResponse(accessToken, user.getId(), user.getNickname());
+        return new LoginResult(response, rawRefreshToken);
+    }
+
+    public DuplicateCheckResponse checkDuplicate(String type, String value) {
+        boolean exists = switch (type.toUpperCase()) {
+            case "EMAIL" -> userRepository.existsByEmail(value);
+            case "NICKNAME" -> userRepository.existsByNickname(value);
+            default -> throw new GeneralException(GeneralErrorCode.BAD_REQUEST);
+        };
+
+        return new DuplicateCheckResponse(!exists);
+    }
+
+    @Transactional
+    public TokenReissueResult reissue(String rawRefreshToken) {
+        RefreshToken stored = refreshTokenRepository.findByToken(hashToken(rawRefreshToken))
+                .orElseThrow(() -> new GeneralException(AuthErrorCode.INVALID_REFRESH_TOKEN));
+
+        if (stored.isRevoked() || stored.getExpiresAt().isBefore(LocalDateTime.now())) {
+            throw new GeneralException(AuthErrorCode.INVALID_REFRESH_TOKEN);
+        }
+
+        stored.revoke();
+
+        User user = stored.getUser();
+        String newAccessToken = jwtProvider.generateAccessToken(user.getId());
+        String newRawRefreshToken = jwtProvider.generateRefreshToken(user.getId());
+        saveRefreshToken(user, newRawRefreshToken);
+
+        TokenReissueResponse response = new TokenReissueResponse(newAccessToken);
+        return new TokenReissueResult(response, newRawRefreshToken);
+    }
+
+    @Transactional
+    public void logout(String rawRefreshToken) {
+        if (!StringUtils.hasText(rawRefreshToken)) {
+            return;
+        }
+
+        refreshTokenRepository.findByToken(hashToken(rawRefreshToken))
+                .ifPresent(refreshToken -> refreshTokenRepository.deleteAllByUser_Id(refreshToken.getUser().getId()));
+    }
+
+    public MeResponse getMe(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(AuthErrorCode.USER_NOT_FOUND));
+
+        return new MeResponse(user.getId(), user.getEmail(), user.getNickname());
+    }
+
+    private void saveRefreshToken(User user, String rawRefreshToken) {
+        LocalDateTime expiresAt = LocalDateTime.ofInstant(
+                jwtProvider.getExpiration(rawRefreshToken).toInstant(),
+                ZoneId.systemDefault()
+        );
+
+        RefreshToken refreshToken = RefreshToken.builder()
+                .user(user)
+                .token(hashToken(rawRefreshToken))
+                .expiresAt(expiresAt)
+                .build();
+        refreshTokenRepository.save(refreshToken);
+    }
+
+    private String hashToken(String rawToken) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(rawToken.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(hash);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 알고리즘을 사용할 수 없습니다.", e);
+        }
+    }
+}

--- a/src/main/java/AIFinance/demo/global/config/SecurityConfig.java
+++ b/src/main/java/AIFinance/demo/global/config/SecurityConfig.java
@@ -1,0 +1,63 @@
+package AIFinance.demo.global.config;
+
+import AIFinance.demo.auth.jwt.JwtAuthenticationFilter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
+
+@Configuration
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(HttpMethod.POST, "/api/v1/auth/signup").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/api/v1/auth/login").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/v1/auth/check").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/api/v1/auth/refresh").permitAll()
+                        .requestMatchers("/api/v1/**").authenticated()
+                        .anyRequest().permitAll()
+                )
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOrigins(List.of("http://localhost:5173"));
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+        configuration.setAllowedHeaders(List.of("*"));
+        configuration.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
+    }
+}

--- a/src/main/java/AIFinance/demo/user/repository/UserRepository.java
+++ b/src/main/java/AIFinance/demo/user/repository/UserRepository.java
@@ -1,0 +1,16 @@
+package AIFinance.demo.user.repository;
+
+import AIFinance.demo.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    boolean existsByEmail(String email);
+
+    boolean existsByNickname(String nickname);
+
+    Optional<User> findByEmail(String email);
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,12 @@
 spring.application.name=demo
+
+spring.datasource.url=${DB_URL}
+spring.datasource.username=${DB_USERNAME}
+spring.datasource.password=${DB_PASSWORD}
+
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.properties.hibernate.format_sql=true
+
+jwt.secret=${JWT_SECRET}
+jwt.access-expiration-ms=900000
+jwt.refresh-expiration-ms=1209600000

--- a/src/test/java/AIFinance/demo/auth/service/AuthServiceTest.java
+++ b/src/test/java/AIFinance/demo/auth/service/AuthServiceTest.java
@@ -1,0 +1,167 @@
+package AIFinance.demo.auth.service;
+
+import AIFinance.demo.auth.dto.*;
+import AIFinance.demo.auth.exception.AuthErrorCode;
+import AIFinance.demo.auth.jwt.JwtProvider;
+import AIFinance.demo.auth.repository.RefreshTokenRepository;
+import AIFinance.demo.global.apiPayload.code.GeneralErrorCode;
+import AIFinance.demo.global.apiPayload.exception.GeneralException;
+import AIFinance.demo.user.entity.User;
+import AIFinance.demo.user.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Date;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @Mock
+    private JwtProvider jwtProvider;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @InjectMocks
+    private AuthService authService;
+
+    @Test
+    void signup_성공하면_User를_저장하고_응답을_반환한다() {
+        SignupRequest request = new SignupRequest("test@test.com", "password1", "tester");
+
+        when(userRepository.existsByEmail(request.email())).thenReturn(false);
+        when(userRepository.existsByNickname(request.nickname())).thenReturn(false);
+        when(passwordEncoder.encode(request.password())).thenReturn("encoded-password");
+        when(userRepository.save(any(User.class))).thenAnswer(invocation -> {
+            User savedUser = invocation.getArgument(0);
+            ReflectionTestUtils.setField(savedUser, "id", 1L);
+            return savedUser;
+        });
+
+        SignupResponse response = authService.signup(request);
+
+        assertThat(response.userId()).isEqualTo(1L);
+        assertThat(response.email()).isEqualTo(request.email());
+        assertThat(response.nickname()).isEqualTo(request.nickname());
+        verify(userRepository).save(any(User.class));
+    }
+
+    @Test
+    void signup_이메일이_중복이면_예외를_던지고_저장하지_않는다() {
+        SignupRequest request = new SignupRequest("dup@test.com", "password1", "tester");
+
+        when(userRepository.existsByEmail(request.email())).thenReturn(true);
+
+        assertThatThrownBy(() -> authService.signup(request))
+                .isInstanceOf(GeneralException.class)
+                .extracting("code")
+                .isEqualTo(AuthErrorCode.EMAIL_DUPLICATE);
+
+        verify(userRepository, never()).save(any(User.class));
+    }
+
+    @Test
+    void login_성공하면_토큰을_발급하고_refreshToken을_저장한다() {
+        LoginRequest request = new LoginRequest("test@test.com", "password1");
+        User user = User.builder()
+                .id(1L)
+                .email(request.email())
+                .password("encoded-password")
+                .nickname("tester")
+                .build();
+
+        when(userRepository.findByEmail(request.email())).thenReturn(Optional.of(user));
+        when(passwordEncoder.matches(request.password(), user.getPassword())).thenReturn(true);
+        when(jwtProvider.generateAccessToken(user.getId())).thenReturn("access-token");
+        when(jwtProvider.generateRefreshToken(user.getId())).thenReturn("refresh-token");
+        when(jwtProvider.getExpiration("refresh-token"))
+                .thenReturn(new Date(System.currentTimeMillis() + 1_209_600_000L));
+
+        LoginResult result = authService.login(request);
+
+        assertThat(result.refreshToken()).isEqualTo("refresh-token");
+        assertThat(result.response().accessToken()).isEqualTo("access-token");
+        assertThat(result.response().userId()).isEqualTo(user.getId());
+        assertThat(result.response().nickname()).isEqualTo(user.getNickname());
+        verify(refreshTokenRepository).save(any());
+    }
+
+    @Test
+    void login_비밀번호가_틀리면_예외를_던지고_토큰을_발급하지_않는다() {
+        LoginRequest request = new LoginRequest("test@test.com", "wrong-password");
+        User user = User.builder()
+                .id(1L)
+                .email(request.email())
+                .password("encoded-password")
+                .nickname("tester")
+                .build();
+
+        when(userRepository.findByEmail(request.email())).thenReturn(Optional.of(user));
+        when(passwordEncoder.matches(request.password(), user.getPassword())).thenReturn(false);
+
+        assertThatThrownBy(() -> authService.login(request))
+                .isInstanceOf(GeneralException.class)
+                .extracting("code")
+                .isEqualTo(AuthErrorCode.INVALID_CREDENTIALS);
+
+        verify(jwtProvider, never()).generateAccessToken(any());
+        verify(refreshTokenRepository, never()).save(any());
+    }
+
+    @Test
+    void login_존재하지_않는_이메일이면_예외를_던진다() {
+        LoginRequest request = new LoginRequest("noone@test.com", "password1");
+
+        when(userRepository.findByEmail(request.email())).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> authService.login(request))
+                .isInstanceOf(GeneralException.class)
+                .extracting("code")
+                .isEqualTo(AuthErrorCode.INVALID_CREDENTIALS);
+    }
+
+    @Test
+    void checkDuplicate_EMAIL_타입이면_existsByEmail의_반대값을_반환한다() {
+        when(userRepository.existsByEmail("test@test.com")).thenReturn(false);
+
+        DuplicateCheckResponse response = authService.checkDuplicate("EMAIL", "test@test.com");
+
+        assertThat(response.available()).isTrue();
+    }
+
+    @Test
+    void checkDuplicate_NICKNAME_타입이고_이미_사용중이면_available이_false다() {
+        when(userRepository.existsByNickname("tester")).thenReturn(true);
+
+        DuplicateCheckResponse response = authService.checkDuplicate("NICKNAME", "tester");
+
+        assertThat(response.available()).isFalse();
+    }
+
+    @Test
+    void checkDuplicate_지원하지_않는_type이면_BAD_REQUEST_예외를_던진다() {
+        assertThatThrownBy(() -> authService.checkDuplicate("INVALID", "value"))
+                .isInstanceOf(GeneralException.class)
+                .extracting("code")
+                .isEqualTo(GeneralErrorCode.BAD_REQUEST);
+    }
+}


### PR DESCRIPTION
## 관련 이슈
Closes #20 

## 작업 내용
<!-- 이 PR에서 진행한 작업을 간단히 설명해주세요. -->
JWT access(15분)+refresh(14일, DB 저장/회전) 방식으로 6개 엔드포인트 구현.

- SecurityConfig, JwtProvider, JwtAuthenticationFilter
- RefreshToken 엔티티/레포지토리, UserRepository
- AuthController, AuthService, AuthErrorCode, DTO
- AuthService 단위 테스트

## 주요 변경 사항
<!-- 주요 변경 사항을 작성해주세요. -->
-
-
-

## 동작 흐름
<!-- 변경된 기능의 동작 흐름이나 처리 과정을 작성해주세요. 해당하지 않는 경우 삭제해주세요. -->
-
-
-

## 응답 예시
<!-- API 응답이나 실행 결과가 있다면 작성해주세요. 해당하지 않는 경우 삭제해주세요. -->

```json
{
}
```

## AI 사용 여부
- [ ] 사용함
- [ ] 사용하지 않음

### 사용한 AI 기능
<!-- AI를 사용한 경우에만 작성해주세요. -->

- AI 기능/도구:
- 사용 범위:
- 생성된 코드 직접 검토 여부: [ ] Yes
- AI 생성 코드를 수정했나요?: [ ] Yes / [ ] No

## 팀원이 확인해야 할 것

<!-- 리뷰 시 중점적으로 확인해야 할 내용이 있다면 작성해주세요. -->

-
