### PR TITLE
[FEAT] 송금 상태 관리 및 정산 종료 API 구현

### DIFF
--- a/src/main/java/AIFinance/demo/settlement/controller/SettlementController.java
+++ b/src/main/java/AIFinance/demo/settlement/controller/SettlementController.java
@@ -1,0 +1,27 @@
+package AIFinance.demo.settlement.controller;
+
+import AIFinance.demo.global.apiPayload.ApiResponse;
+import AIFinance.demo.settlement.dto.SettlementResponse;
+import AIFinance.demo.settlement.exception.code.SettlementSuccessCode;
+import AIFinance.demo.settlement.service.SettlementService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/trips/{tripId}/settlement")
+public class SettlementController {
+
+    private final SettlementService settlementService;
+
+    @PatchMapping("/complete")
+    public ApiResponse<SettlementResponse.SettlementCompleted> completeSettlement(@AuthenticationPrincipal Long userId, @PathVariable Long tripId) {
+        SettlementResponse.SettlementCompleted response = settlementService.completeSettlement(userId, tripId);
+
+        return ApiResponse.onSuccess(SettlementSuccessCode.SETTLEMENT_COMPLETED, response);
+    }
+}

--- a/src/main/java/AIFinance/demo/settlement/controller/SettlementTransferController.java
+++ b/src/main/java/AIFinance/demo/settlement/controller/SettlementTransferController.java
@@ -1,0 +1,32 @@
+package AIFinance.demo.settlement.controller;
+
+import AIFinance.demo.global.apiPayload.ApiResponse;
+import AIFinance.demo.settlement.dto.SettlementResponse;
+import AIFinance.demo.settlement.exception.code.SettlementSuccessCode;
+import AIFinance.demo.settlement.service.SettlementTransferService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/trips/{tripId}/transfers")
+public class SettlementTransferController {
+
+    private final SettlementTransferService settlementTransferService;
+
+    @PatchMapping("/{transferId}/sent")
+    public ApiResponse<SettlementResponse.TransferSent> markTransferSent(@AuthenticationPrincipal Long userId, @PathVariable Long tripId, @PathVariable Long transferId) {
+        SettlementResponse.TransferSent response = settlementTransferService.markTransferSent(userId, tripId, transferId);
+
+        return ApiResponse.onSuccess(SettlementSuccessCode.TRANSFER_SENT, response);
+    }
+
+    @PatchMapping("/{transferId}/confirmed")
+    public ApiResponse<SettlementResponse.TransferConfirmed> confirmTransfer(@AuthenticationPrincipal Long userId, @PathVariable Long tripId, @PathVariable Long transferId) {
+        SettlementResponse.TransferConfirmed response = settlementTransferService.confirmTransfer(userId, tripId, transferId);
+
+        return ApiResponse.onSuccess(SettlementSuccessCode.TRANSFER_CONFIRMED, response);
+    }
+
+}

--- a/src/main/java/AIFinance/demo/settlement/dto/SettlementResponse.java
+++ b/src/main/java/AIFinance/demo/settlement/dto/SettlementResponse.java
@@ -1,0 +1,48 @@
+package AIFinance.demo.settlement.dto;
+
+import AIFinance.demo.settlement.entity.Settlement;
+import AIFinance.demo.settlement.entity.SettlementTransfer;
+import AIFinance.demo.settlement.entity.enums.SettlementStatus;
+import AIFinance.demo.settlement.entity.enums.SettlementTransferStatus;
+
+import java.time.LocalDateTime;
+
+public class SettlementResponse {
+
+    private SettlementResponse() {}
+
+    public record TransferSent(Long transferId, Long settlementId, SettlementTransferStatus status, LocalDateTime sentAt) {
+        public static TransferSent from(SettlementTransfer transfer){
+            return new TransferSent(
+                    transfer.getId(),
+                    transfer.getSettlement().getId(),
+                    transfer.getStatus(),
+                    transfer.getSentAt()
+            );
+        }
+    }
+
+    public record TransferConfirmed(Long transferId, Long settlementId, SettlementTransferStatus status, LocalDateTime sentAt, LocalDateTime confirmedAt) {
+        public static TransferConfirmed from(SettlementTransfer transfer){
+            return new TransferConfirmed(
+                    transfer.getId(),
+                    transfer.getSettlement().getId(),
+                    transfer.getStatus(),
+                    transfer.getSentAt(),
+                    transfer.getConfirmedAt()
+            );
+        }
+    }
+
+    public record SettlementCompleted(Long settlementId, Long tripId, SettlementStatus status, LocalDateTime completedAt) {
+        public static SettlementCompleted from(Settlement settlement){
+            return new SettlementCompleted(
+                    settlement.getId(),
+                    settlement.getTrip().getId(),
+                    settlement.getStatus(),
+                    settlement.getCompletedAt()
+            );
+        }
+    }
+
+}

--- a/src/main/java/AIFinance/demo/settlement/entity/SettlementTransfer.java
+++ b/src/main/java/AIFinance/demo/settlement/entity/SettlementTransfer.java
@@ -63,7 +63,7 @@ public class SettlementTransfer extends BaseEntity {
     }
 
     public void confirm() {
-        this.status =  SettlementTransferStatus.COMPLETED;
+        this.status = SettlementTransferStatus.COMPLETED;
         this.confirmedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/AIFinance/demo/settlement/exception/SettlementException.java
+++ b/src/main/java/AIFinance/demo/settlement/exception/SettlementException.java
@@ -1,0 +1,10 @@
+package AIFinance.demo.settlement.exception;
+
+import AIFinance.demo.global.apiPayload.code.BaseErrorCode;
+import AIFinance.demo.global.apiPayload.exception.GeneralException;
+
+public class SettlementException extends GeneralException {
+    public SettlementException(BaseErrorCode code) {
+        super(code);
+    }
+}

--- a/src/main/java/AIFinance/demo/settlement/exception/code/SettlementErrorCode.java
+++ b/src/main/java/AIFinance/demo/settlement/exception/code/SettlementErrorCode.java
@@ -1,0 +1,39 @@
+package AIFinance.demo.settlement.exception.code;
+
+import AIFinance.demo.global.apiPayload.code.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum SettlementErrorCode implements BaseErrorCode {
+
+    TRIP_NOT_FOUND(HttpStatus.NOT_FOUND, "TRIP_NOT_FOUND", "여행방을 찾을 수 없습니다."),
+
+    INVALID_TRIP_STATUS(HttpStatus.CONFLICT, "INVALID_TRIP_STATUS", "정산 진행 중인 여행방에서만 처리할 수 있습니다."),
+
+    TRANSFER_NOT_FOUND(HttpStatus.NOT_FOUND, "TRANSFER_NOT_FOUND", "해당 여행방에서 송금 건을 찾을 수 없습니다."),
+
+    TRANSFER_SENDER_REQUIRED(HttpStatus.FORBIDDEN, "TRANSFER_SENDER_REQUIRED", "해당 송금 건의 송금자만 완료 표시할 수 있습니다."),
+
+    TRANSFER_RECEIVER_REQUIRED(HttpStatus.FORBIDDEN, "TRANSFER_RECEIVER_REQUIRED", "해당 송금 건의 수취인만 입금을 확인할 수 있습니다."),
+
+    TRANSFER_ALREADY_SENT(HttpStatus.CONFLICT, "TRANSFER_ALREADY_SENT", "이미 송금 완료로 표시된 송금 건입니다."),
+
+    TRANSFER_NOT_SENT(HttpStatus.CONFLICT, "TRANSFER_NOT_SENT", "송금 완료 표시 후 입금을 확인할 수 있습니다."),
+
+    TRANSFER_ALREADY_CONFIRMED(HttpStatus.CONFLICT, "TRANSFER_ALREADY_CONFIRMED", "이미 입금 확인이 완료된 송금 건입니다."),
+
+    SETTLEMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "SETTLEMENT_NOT_FOUND", "확정된 정산을 찾을 수 없습니다."),
+
+    TRIP_OWNER_REQUIRED(HttpStatus.FORBIDDEN, "TRIP_OWNER_REQUIRED", "여행방의 방장만 정산을 종료할 수 있습니다."),
+
+    SETTLEMENT_ALREADY_COMPLETED(HttpStatus.CONFLICT, "SETTLEMENT_ALREADY_COMPLETED", "이미 종료된 정산입니다."),
+
+    INCOMPLETE_TRANSFERS(HttpStatus.CONFLICT, "INCOMPLETE_TRANSFERS", "완료되지 않은 송금 건이 남아 있습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/AIFinance/demo/settlement/exception/code/SettlementSuccessCode.java
+++ b/src/main/java/AIFinance/demo/settlement/exception/code/SettlementSuccessCode.java
@@ -1,0 +1,20 @@
+package AIFinance.demo.settlement.exception.code;
+
+import AIFinance.demo.global.apiPayload.code.BaseSuccessCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum SettlementSuccessCode implements BaseSuccessCode {
+    TRANSFER_SENT(HttpStatus.OK, "TRANSFER_SENT", "송금 완료로 표시되었습니다."),
+
+    TRANSFER_CONFIRMED(HttpStatus.OK, "TRANSFER_CONFIRMED", "입금이 확인되었습니다."),
+
+    SETTLEMENT_COMPLETED(HttpStatus.OK, "SETTLEMENT_COMPLETED", "정산이 종료되었습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/AIFinance/demo/settlement/repository/SettlementRepository.java
+++ b/src/main/java/AIFinance/demo/settlement/repository/SettlementRepository.java
@@ -3,5 +3,8 @@ package AIFinance.demo.settlement.repository;
 import AIFinance.demo.settlement.entity.Settlement;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface SettlementRepository extends JpaRepository<Settlement, Long> {
+    Optional<Settlement> findByTrip_Id(Long tripId);
 }

--- a/src/main/java/AIFinance/demo/settlement/repository/SettlementTransferRepository.java
+++ b/src/main/java/AIFinance/demo/settlement/repository/SettlementTransferRepository.java
@@ -1,7 +1,15 @@
 package AIFinance.demo.settlement.repository;
 
 import AIFinance.demo.settlement.entity.SettlementTransfer;
+import AIFinance.demo.settlement.entity.enums.SettlementTransferStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface SettlementTransferRepository extends JpaRepository<SettlementTransfer, Long> {
+
+    Optional<SettlementTransfer> findByIdAndSettlement_Trip_Id(Long transferId, Long tripId);
+
+    boolean existsBySettlement_IdAndStatusNot(Long settlementId, SettlementTransferStatus status);
+
 }

--- a/src/main/java/AIFinance/demo/settlement/service/SettlementService.java
+++ b/src/main/java/AIFinance/demo/settlement/service/SettlementService.java
@@ -1,0 +1,85 @@
+package AIFinance.demo.settlement.service;
+
+import AIFinance.demo.settlement.dto.SettlementResponse;
+import AIFinance.demo.settlement.entity.Settlement;
+import AIFinance.demo.settlement.entity.enums.SettlementStatus;
+import AIFinance.demo.settlement.entity.enums.SettlementTransferStatus;
+import AIFinance.demo.settlement.exception.SettlementException;
+import AIFinance.demo.settlement.exception.code.SettlementErrorCode;
+import AIFinance.demo.settlement.repository.SettlementRepository;
+import AIFinance.demo.settlement.repository.SettlementTransferRepository;
+import AIFinance.demo.trip.entity.Trip;
+import AIFinance.demo.trip.entity.enums.TripStatus;
+import AIFinance.demo.trip.repository.TripRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Objects;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class SettlementService {
+
+    private final TripRepository tripRepository;
+    private final SettlementRepository settlementRepository;
+    private final SettlementTransferRepository settlementTransferRepository;
+
+    @Transactional
+    public SettlementResponse.SettlementCompleted completeSettlement(Long userId, Long tripId) {
+        Trip trip = getTrip(tripId);
+        validateOwner(trip, userId);
+
+        Settlement settlement = getSettlement(tripId);
+
+        validateSettlementStatus(settlement);
+        validateTripStatus(trip);
+        validateAllTransfersCompleted(settlement);
+
+        settlement.complete();
+        trip.completeSettlement();
+
+        return SettlementResponse.SettlementCompleted.from(settlement);
+    }
+
+    private Trip getTrip(Long tripId) {
+        return tripRepository.findById(tripId)
+                .orElseThrow(() -> new SettlementException(SettlementErrorCode.TRIP_NOT_FOUND));
+    }
+
+    private Settlement getSettlement(Long tripId) {
+        return settlementRepository.findByTrip_Id(tripId)
+                .orElseThrow(() -> new SettlementException(SettlementErrorCode.SETTLEMENT_NOT_FOUND));
+    }
+
+    private void validateOwner(Trip trip, Long userId) {
+        Long ownerUserId = trip.getOwner().getId();
+
+        if (!Objects.equals(userId, ownerUserId)) {
+            throw new SettlementException(SettlementErrorCode.TRIP_OWNER_REQUIRED);
+        }
+    }
+
+    private void validateSettlementStatus(Settlement settlement) {
+        if (settlement.getStatus() == SettlementStatus.COMPLETED) {
+            throw new SettlementException(SettlementErrorCode.SETTLEMENT_ALREADY_COMPLETED);
+        }
+    }
+
+    private void validateTripStatus(Trip trip) {
+        if (trip.getStatus() != TripStatus.SETTLING) {
+            throw new SettlementException(SettlementErrorCode.INVALID_TRIP_STATUS);
+        }
+    }
+
+    private void validateAllTransfersCompleted(Settlement settlement) {
+
+        boolean hasIncompleteTransfers = settlementTransferRepository
+                .existsBySettlement_IdAndStatusNot(settlement.getId(), SettlementTransferStatus.COMPLETED);
+
+        if (hasIncompleteTransfers) {
+            throw new SettlementException(SettlementErrorCode.INCOMPLETE_TRANSFERS);
+        }
+    }
+}

--- a/src/main/java/AIFinance/demo/settlement/service/SettlementTransferService.java
+++ b/src/main/java/AIFinance/demo/settlement/service/SettlementTransferService.java
@@ -1,0 +1,102 @@
+package AIFinance.demo.settlement.service;
+
+import AIFinance.demo.settlement.dto.SettlementResponse;
+import AIFinance.demo.settlement.entity.SettlementTransfer;
+import AIFinance.demo.settlement.entity.enums.SettlementTransferStatus;
+import AIFinance.demo.settlement.exception.SettlementException;
+import AIFinance.demo.settlement.exception.code.SettlementErrorCode;
+import AIFinance.demo.settlement.repository.SettlementTransferRepository;
+import AIFinance.demo.trip.entity.Trip;
+import AIFinance.demo.trip.entity.enums.TripStatus;
+import AIFinance.demo.trip.repository.TripRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Objects;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class SettlementTransferService {
+
+    private final TripRepository tripRepository;
+    private final SettlementTransferRepository settlementTransferRepository;
+
+    @Transactional
+    public SettlementResponse.TransferSent markTransferSent(Long userId, Long tripId, Long transferId) {
+        Trip trip = getTrip(tripId); // 여행방 조회
+        validateTripStatus(trip); // 여행방 상태 SETTLING 인지 조회
+
+        SettlementTransfer transfer = getTransfer(transferId, tripId); // 여행방의 송금 건 조회
+        validateSender(transfer, userId); // 현재 사용자가 해당 송금 건의 송금자인지 조회
+        validateCanMarkSent(transfer); // 송금 상태 PENDING 인지 조회
+
+        transfer.markSent();
+
+        return SettlementResponse.TransferSent.from(transfer);
+    }
+
+    @Transactional
+    public SettlementResponse.TransferConfirmed confirmTransfer(Long userId, Long tripId, Long transferId) {
+        Trip trip = getTrip(tripId); // 여행방 조회
+        validateTripStatus(trip); // 여행방 상태 SETTLING 인지 조회
+
+        SettlementTransfer transfer = getTransfer(transferId, tripId); // 여행방의 송금 건 조회
+        validateReceiver(transfer, userId); // 현재 사용자가 송금 건의 수취인인지 조회
+        validateCanConfirm(transfer); // 여행방 상태 SENT 인지 조회
+
+        transfer.confirm();
+
+        return SettlementResponse.TransferConfirmed.from(transfer);
+    }
+
+    private Trip getTrip(Long tripId) {
+        return tripRepository.findById(tripId)
+                .orElseThrow(() -> new SettlementException(SettlementErrorCode.TRIP_NOT_FOUND));
+    }
+
+    private SettlementTransfer getTransfer(Long transferId, Long tripId) {
+        return settlementTransferRepository
+                .findByIdAndSettlement_Trip_Id(transferId, tripId)
+                .orElseThrow(() -> new SettlementException(SettlementErrorCode.TRANSFER_NOT_FOUND));
+    }
+
+    private void validateTripStatus(Trip trip) {
+        if (trip.getStatus() != TripStatus.SETTLING) {
+            throw new SettlementException(SettlementErrorCode.INVALID_TRIP_STATUS);
+        }
+    }
+
+    private void validateSender(SettlementTransfer transfer, Long userId) {
+        Long senderUserId = transfer.getSenderMember().getUser().getId();
+
+        if (!Objects.equals(senderUserId, userId)) {
+            throw new SettlementException(SettlementErrorCode.TRANSFER_SENDER_REQUIRED);
+        }
+    }
+
+    private void validateReceiver(SettlementTransfer transfer, Long userId) {
+        Long receiverUserId = transfer.getReceiverMember().getUser().getId();
+
+        if (!Objects.equals(receiverUserId, userId)) {
+            throw new SettlementException(SettlementErrorCode.TRANSFER_RECEIVER_REQUIRED);
+        }
+    }
+
+    private void validateCanMarkSent(SettlementTransfer transfer) {
+        if (transfer.getStatus() != SettlementTransferStatus.PENDING) {
+            throw new SettlementException(SettlementErrorCode.TRANSFER_ALREADY_SENT);
+        }
+    }
+
+    private void validateCanConfirm(SettlementTransfer transfer) {
+        if (transfer.getStatus() == SettlementTransferStatus.PENDING) {
+            throw new SettlementException(SettlementErrorCode.TRANSFER_NOT_SENT);
+        }
+
+        if (transfer.getStatus() == SettlementTransferStatus.COMPLETED) {
+            throw new SettlementException(SettlementErrorCode.TRANSFER_ALREADY_CONFIRMED);
+        }
+    }
+}

--- a/src/main/java/AIFinance/demo/trip/entity/Trip.java
+++ b/src/main/java/AIFinance/demo/trip/entity/Trip.java
@@ -45,6 +45,11 @@ public class Trip extends BaseEntity {
     @Column(name = "invite_expires_at")
     private LocalDateTime inviteExpiresAt;
 
+    public void completeSettlement() {
+        this.status = TripStatus.COMPLETED;
+    }
+
+
     public void regenerateInvite(String inviteCode, LocalDateTime inviteExpiresAt) {
         this.inviteCode = inviteCode;
         this.inviteExpiresAt = inviteExpiresAt;


### PR DESCRIPTION
## 관련 이슈
Closes #22

## 작업 내용
<!-- 이 PR에서 진행한 작업을 간단히 설명해주세요. -->
- 송금자가 송금 완료 여부를 표시하는 API를 구현했습니다.
- 수취인이 입금 여부를 확인하는 API를 구현했습니다.
- 입금 확인 완료 시 송금 건을 자동으로 완료 처리하도록 구현했습니다.
- 모든 송금 건 완료 후 방장이 여행 정산을 종료하는 API를 구현했습니다.

## 주요 변경 사항
<!-- 주요 변경 사항을 작성해주세요. -->
- 송금 완료 표시 API 구현
- 입금 확인 API 구현
- 정산 종료 API 구현
- 송금·정산 상태 변경 응답 DTO 추가
- SETTLE 도메인 성공 코드 및 예외 코드 추가
- 송금자·수취인·방장 권한 검증 추가
- 여행·정산·송금 상태 검증 추가
- 미완료 송금 건 조회 Repository 메서드 추가
- JWT 인증 사용자 정보를 `@AuthenticationPrincipal`로 주입
- 정산 종료 시 `Settlement`와 `Trip`을 `COMPLETED`로 변경

## 동작 흐름
<!-- 변경된 기능의 동작 흐름이나 처리 과정을 작성해주세요. 해당하지 않는 경우 삭제해주세요. -->
### 송금 완료 표시

- 여행방과 송금 건을 조회합니다.
- 여행 상태가 `SETTLING`인지 확인합니다.
- 요청자가 해당 송금 건의 송금자인지 확인합니다.
- 송금 상태가 `PENDING`인지 확인합니다.
- 송금 상태를 `SENT`로 변경하고 `sentAt`을 기록합니다.

### 입금 확인

- 여행방과 송금 건을 조회합니다.
- 요청자가 해당 송금 건의 수취인인지 확인합니다.
- 송금 완료 표시가 먼저 처리되었는지 확인합니다.
- 송금 상태를 `COMPLETED`로 변경하고 `confirmedAt`을 기록합니다.

### 정산 종료

- 요청자가 여행방의 방장인지 확인합니다.
- 여행 및 정산 상태를 확인합니다.
- 완료되지 않은 송금 건이 존재하는지 확인합니다.
- 모든 송금 건이 완료되었거나 송금 건이 0개이면 정산을 종료합니다.
- `Settlement`와 `Trip`을 `COMPLETED`로 변경하고 정산 완료 시간을 기록합니다.

## 응답 예시
<!-- API 응답이나 실행 결과가 있다면 작성해주세요. 해당하지 않는 경우 삭제해주세요. -->

```json
{
  "isSuccess": true,
  "code": "TRANSFER_CONFIRMED",
  "message": "입금이 확인되었습니다.",
  "result": {
    "transferId": 30,
    "settlementId": 20,
    "status": "COMPLETED",
    "sentAt": "2026-08-27T18:30:00",
    "confirmedAt": "2026-08-27T18:35:00"
  }
}
```

## AI 사용 여부
- [x] 사용함
- [ ] 사용하지 않음

### 사용한 AI 기능
<!-- AI를 사용한 경우에만 작성해주세요. -->

- AI 기능/도구: ChatGPT Codex
- 사용 범위: 상태 전이 및 검증 로직 검토, 코드 리뷰
- 생성된 코드 직접 검토 여부: [ ] Yes
- AI 생성 코드를 수정했나요?: [ ] Yes / [ ] No
