### PR TITLE
[REFACTOR] COST API JWT 인증 사용자 연동

### DIFF
--- a/src/main/java/AIFinance/demo/receipt/controller/ReceiptItemController.java
+++ b/src/main/java/AIFinance/demo/receipt/controller/ReceiptItemController.java
@@ -7,6 +7,7 @@ import AIFinance.demo.receipt.exception.code.ReceiptItemSuccessCode;
 import AIFinance.demo.receipt.service.ReceiptItemService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -19,43 +20,26 @@ public class ReceiptItemController {
     @PostMapping
     public ApiResponse<ReceiptItemResponse.CreatedAdditionalCost>
     createAdditionalCost(
-            @RequestHeader("X-USER-ID") Long userId,
-            @PathVariable Long tripId,
-            @PathVariable Long receiptId,
-            @Valid @RequestBody
-            ReceiptItemRequest.CreateAdditionalCost request
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long tripId, @PathVariable 
+            Long receiptId,
+            @Valid @RequestBody ReceiptItemRequest.CreateAdditionalCost request
     ) {
-        ReceiptItemResponse.CreatedAdditionalCost result =
-                receiptItemService.createAdditionalCost(
-                        userId,
-                        tripId,
-                        receiptId,
-                        request
-                );
 
-        return ApiResponse.onSuccess(
-                ReceiptItemSuccessCode.ADDITIONAL_COST_CREATED,
-                result
-        );
+        ReceiptItemResponse.CreatedAdditionalCost result = receiptItemService.createAdditionalCost(userId, tripId, receiptId, request);
+
+        return ApiResponse.onSuccess(ReceiptItemSuccessCode.ADDITIONAL_COST_CREATED, result);
     }
 
     @DeleteMapping("/{itemId}")
     public ApiResponse<Void> deleteAdditionalCost(
-            @RequestHeader("X-USER-ID") Long userId,
+            @AuthenticationPrincipal Long userId,
             @PathVariable Long tripId,
             @PathVariable Long receiptId,
             @PathVariable Long itemId
     ) {
-        receiptItemService.deleteAdditionalCost(
-                userId,
-                tripId,
-                receiptId,
-                itemId
-        );
+        receiptItemService.deleteAdditionalCost(userId, tripId, receiptId, itemId);
 
-        return ApiResponse.onSuccess(
-                ReceiptItemSuccessCode.ADDITIONAL_COST_DELETED,
-                null
-        );
+        return ApiResponse.onSuccess(ReceiptItemSuccessCode.ADDITIONAL_COST_DELETED, null);
     }
 }


### PR DESCRIPTION
## 관련 이슈
Closes #31

## 작업 내용
<!-- 이 PR에서 진행한 작업을 간단히 설명해주세요. -->
- COST 추가 비용 등록·삭제 API에서 임시로 사용하던 `X-USER-ID` 헤더를 제거하고, JWT 인증 사용자 정보를 사용하도록 수정했습니다.

## 주요 변경 사항
<!-- 주요 변경 사항을 작성해주세요. -->
- 추가 비용 등록 API의 `X-USER-ID` 헤더 제거
- 추가 비용 삭제 API의 `X-USER-ID` 헤더 제거
- `@AuthenticationPrincipal Long userId` 적용
- JWT 인증 필터에서 검증된 사용자 ID를 기존 Service에 전달
- COST API 명세에서 임시 인증 헤더 관련 내용 제거

## 동작 흐름
<!-- 변경된 기능의 동작 흐름이나 처리 과정을 작성해주세요. 해당하지 않는 경우 삭제해주세요. -->
- 클라이언트가 `Authorization: Bearer {accessToken}`을 전달합니다.
- JWT 인증 필터가 토큰을 검증하고 사용자 ID를 인증 principal에 저장합니다.
- Controller가 `@AuthenticationPrincipal`로 사용자 ID를 주입받습니다.
- 주입받은 사용자 ID를 기존 `ReceiptItemService`에 전달합니다.
- Service에서 여행방 참여 여부와 여행 상태를 기존과 동일하게 검증합니다.

## 응답 예시

## 응답 예시
<!-- API 응답이나 실행 결과가 있다면 작성해주세요. 해당하지 않는 경우 삭제해주세요. -->

```json
{
  "isSuccess": true,
  "code": "ADDITIONAL_COST_CREATED",
  "message": "추가 비용 항목이 등록되었습니다.",
  "result": {
    "itemId": 101,
    "receiptId": 10,
    "itemName": "배달비",
    "quantity": 1,
    "originalAmount": 3000,
    "settlementAmount": 3000
  }
}
```

## AI 사용 여부
- [ ] 사용함
- [ ] 사용하지 않음

### 사용한 AI 기능
<!-- AI를 사용한 경우에만 작성해주세요. -->

- AI 기능/도구:
- 사용 범위:
- 생성된 코드 직접 검토 여부: [ ] Yes
- AI 생성 코드를 수정했나요?: [ ] Yes / [ ] No

## 팀원이 확인해야 할 것

<!-- 리뷰 시 중점적으로 확인해야 할 내용이 있다면 작성해주세요. -->

-
