### PR TITLE
[FIX] 추가 비용 삭제 시 ItemShare 연관 데이터 처리

### DIFF
--- a/src/main/java/AIFinance/demo/receipt/service/ReceiptItemService.java
+++ b/src/main/java/AIFinance/demo/receipt/service/ReceiptItemService.java
@@ -7,6 +7,7 @@ import AIFinance.demo.receipt.entity.ReceiptItem;
 import AIFinance.demo.receipt.entity.enums.ReceiptStatus;
 import AIFinance.demo.receipt.exception.ReceiptItemException;
 import AIFinance.demo.receipt.exception.code.ReceiptItemErrorCode;
+import AIFinance.demo.receipt.repository.ItemShareRepository;
 import AIFinance.demo.receipt.repository.ReceiptItemRepository;
 import AIFinance.demo.receipt.repository.ReceiptRepository;
 import AIFinance.demo.trip.entity.Trip;
@@ -27,6 +28,7 @@ public class ReceiptItemService {
     private final TripMemberRepository tripMemberRepository;
     private final ReceiptRepository receiptRepository;
     private final ReceiptItemRepository receiptItemRepository;
+    private final ItemShareRepository itemShareRepository;
 
     @Transactional
     public ReceiptItemResponse.CreatedAdditionalCost createAdditionalCost(Long userId, Long tripId, Long receiptId, ReceiptItemRequest.CreateAdditionalCost request) {
@@ -62,6 +64,7 @@ public class ReceiptItemService {
 
         validateAdditionalCost(receiptItem);
 
+        itemShareRepository.deleteByItem_Id(receiptItem.getId());
         receiptItemRepository.delete(receiptItem);
     }
 


### PR DESCRIPTION
## 관련 이슈
Closes #33

## 작업 내용
<!-- 이 PR에서 진행한 작업을 간단히 설명해주세요. -->
- 부담자가 지정된 추가 비용 항목을 삭제할 때 해당 항목에 연결된 `ItemShare`를 먼저 삭제하도록 COST 삭제 로직을 보완했습니다.

## 주요 변경 사항
<!-- 주요 변경 사항을 작성해주세요. -->
- `ReceiptItemService`에 `ItemShareRepository` 의존성 추가
- 추가 비용 항목 삭제 전 연결된 `ItemShare` 삭제
- `ItemShare`와 `ReceiptItem` 삭제를 하나의 트랜잭션에서 처리
- 기존 추가 비용 검증 및 권한 검증 로직 유지

## 동작 흐름
<!-- 변경된 기능의 동작 흐름이나 처리 과정을 작성해주세요. 해당하지 않는 경우 삭제해주세요. -->
- 여행방 존재 여부와 여행 상태를 검증합니다.
- 요청자가 해당 여행방의 활성 참여자인지 검증합니다.
- 영수증이 해당 여행방에 속하고 삭제 상태가 아닌지 검증합니다.
- 삭제 대상이 해당 영수증의 추가 비용 항목인지 검증합니다.
- 해당 추가 비용 항목에 연결된 `ItemShare`를 삭제합니다.
- 이후 `ReceiptItem`을 삭제합니다.
- 두 삭제 과정 중 하나가 실패하면 전체 트랜잭션을 롤백합니다.

## 응답 예시
<!-- API 응답이나 실행 결과가 있다면 작성해주세요. 해당하지 않는 경우 삭제해주세요. -->

```json
{
  "isSuccess": true,
  "code": "ADDITIONAL_COST_DELETED",
  "message": "추가 비용 항목이 삭제되었습니다.",
  "result": null
}
```

## 팀원이 확인해야 할 것

<!-- 리뷰 시 중점적으로 확인해야 할 내용이 있다면 작성해주세요. -->

- 연결된 ItemShare가 없어도 추가 비용 항목은 정상적으로 삭제됩니다.
