### PR TITLE
[FEAT] 잔액 부담자 지정 API 구현

### DIFF
--- a/src/main/java/AIFinance/demo/global/exception/SplitErrorCode.java
+++ b/src/main/java/AIFinance/demo/global/exception/SplitErrorCode.java
@@ -23,7 +23,11 @@ public enum SplitErrorCode implements BaseErrorCode {
 
     ITEM_NOT_FOUND(HttpStatus.NOT_FOUND,
             "SPLIT_ITEM_NOT_FOUND",
-            "해당 상품을 찾을 수 없습니다.");
+            "해당 상품을 찾을 수 없습니다."),
+
+    PARTICIPANT_NOT_IN_ITEM(HttpStatus.BAD_REQUEST,
+            "SPLIT_PARTICIPANT_NOT_IN_ITEM",
+            "지정한 회원이 해당 상품의 참여자가 아닙니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/AIFinance/demo/receipt/controller/ItemSplitController.java
+++ b/src/main/java/AIFinance/demo/receipt/controller/ItemSplitController.java
@@ -3,6 +3,7 @@ package AIFinance.demo.receipt.controller;
 import AIFinance.demo.global.apiPayload.ApiResponse;
 import AIFinance.demo.global.apiPayload.code.GeneralSuccessCode;
 import AIFinance.demo.receipt.dto.ItemParticipantsResponse;
+import AIFinance.demo.receipt.dto.ItemRemainderRequest;
 import AIFinance.demo.receipt.service.ItemSplitService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -22,6 +23,19 @@ public class ItemSplitController {
             @PathVariable Long itemId
     ) {
         ItemParticipantsResponse response = itemSplitService.splitEqual(itemId);
+
+        return ResponseEntity.status(GeneralSuccessCode.OK.getStatus())
+                .body(ApiResponse.onSuccess(GeneralSuccessCode.OK, response));
+    }
+
+    @PostMapping("/remainder")
+    public ResponseEntity<ApiResponse<ItemParticipantsResponse>> splitRemainder(
+            @PathVariable Long tripId,
+            @PathVariable Long receiptId,
+            @PathVariable Long itemId,
+            @RequestBody ItemRemainderRequest request
+    ) {
+        ItemParticipantsResponse response = itemSplitService.splitRemainder(itemId, request);
 
         return ResponseEntity.status(GeneralSuccessCode.OK.getStatus())
                 .body(ApiResponse.onSuccess(GeneralSuccessCode.OK, response));

--- a/src/main/java/AIFinance/demo/receipt/dto/ItemRemainderRequest.java
+++ b/src/main/java/AIFinance/demo/receipt/dto/ItemRemainderRequest.java
@@ -1,4 +1,11 @@
 package AIFinance.demo.receipt.dto;
 
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
 public class ItemRemainderRequest {
+
+    private Long tripMemberId;
 }

--- a/src/main/java/AIFinance/demo/receipt/dto/ItemRemainderRequest.java
+++ b/src/main/java/AIFinance/demo/receipt/dto/ItemRemainderRequest.java
@@ -1,0 +1,4 @@
+package AIFinance.demo.receipt.dto;
+
+public class ItemRemainderRequest {
+}

--- a/src/main/java/AIFinance/demo/receipt/entity/ReceiptItem.java
+++ b/src/main/java/AIFinance/demo/receipt/entity/ReceiptItem.java
@@ -94,4 +94,8 @@ public class ReceiptItem extends BaseEntity {
     public void updateSplitType(SplitType splitType) {
         this.splitType = splitType;
     }
+
+    public void updateRemainderMember(TripMember remainderMember) {
+        this.remainderMember = remainderMember;
+    }
 }

--- a/src/main/java/AIFinance/demo/receipt/service/ItemSplitService.java
+++ b/src/main/java/AIFinance/demo/receipt/service/ItemSplitService.java
@@ -3,6 +3,7 @@ package AIFinance.demo.receipt.service;
 import AIFinance.demo.global.apiPayload.exception.GeneralException;
 import AIFinance.demo.global.exception.SplitErrorCode;
 import AIFinance.demo.receipt.dto.ItemParticipantsResponse;
+import AIFinance.demo.receipt.dto.ItemRemainderRequest;
 import AIFinance.demo.receipt.entity.ItemShare;
 import AIFinance.demo.receipt.entity.ReceiptItem;
 import AIFinance.demo.receipt.entity.enums.SplitType;
@@ -44,6 +45,35 @@ public class ItemSplitService {
         }
 
         item.updateSplitType(SplitType.EQUAL);
+
+        return ItemParticipantsResponse.of(itemId, shares);
+    }
+
+    public ItemParticipantsResponse splitRemainder(Long itemId, ItemRemainderRequest request) {
+        ReceiptItem item = getItem(itemId);
+
+        List<ItemShare> shares = itemShareRepository.findByItem_Id(itemId);
+        if (shares.isEmpty()) {
+            throw new GeneralException(SplitErrorCode.NO_PARTICIPANT_SELECTED);
+        }
+
+        ItemShare remainderShare = shares.stream()
+                .filter(share -> share.getTripMember().getId().equals(request.getTripMemberId()))
+                .findFirst()
+                .orElseThrow(() -> new GeneralException(SplitErrorCode.PARTICIPANT_NOT_IN_ITEM));
+
+        int count = shares.size();
+        long originalAmount = item.getOriginalAmount();
+        long baseAmount = originalAmount / count;
+        long remainder = originalAmount % count;
+
+        for (ItemShare share : shares) {
+            share.updateShareAmount(baseAmount);
+        }
+        remainderShare.updateShareAmount(baseAmount + remainder);
+
+        item.updateSplitType(SplitType.EQUAL);
+        item.updateRemainderMember(remainderShare.getTripMember());
 
         return ItemParticipantsResponse.of(itemId, shares);
     }


### PR DESCRIPTION
## 관련 이슈
Closes #38 

## 작업 내용
<!-- 이 PR에서 진행한 작업을 간단히 설명해주세요. -->
- ItemSplitService에 splitRemainder() 추가 
- SPLIT04 API 구현 
- ReceiptItem에 updateRemainderMember() 추가
- SplitErrorCode에 예외처리 추가 


## AI 사용 여부
- [ ] 사용함
- [x] 사용하지 않음

### 사용한 AI 기능
<!-- AI를 사용한 경우에만 작성해주세요. -->

- AI 기능/도구:
- 사용 범위:
- 생성된 코드 직접 검토 여부: [ ] Yes
- AI 생성 코드를 수정했나요?: [ ] Yes / [ ] No

## 팀원이 확인해야 할 것

<!-- 리뷰 시 중점적으로 확인해야 할 내용이 있다면 작성해주세요. -->

-
