### PR TITLE
[FEAT] 개인 부담 지정 API 구현

### DIFF
--- a/src/main/java/AIFinance/demo/receipt/controller/ItemSplitController.java
+++ b/src/main/java/AIFinance/demo/receipt/controller/ItemSplitController.java
@@ -2,6 +2,7 @@ package AIFinance.demo.receipt.controller;
 
 import AIFinance.demo.global.apiPayload.ApiResponse;
 import AIFinance.demo.global.apiPayload.code.GeneralSuccessCode;
+import AIFinance.demo.receipt.dto.ItemIndividualRequest;
 import AIFinance.demo.receipt.dto.ItemParticipantsResponse;
 import AIFinance.demo.receipt.dto.ItemRemainderRequest;
 import AIFinance.demo.receipt.service.ItemSplitService;
@@ -36,6 +37,19 @@ public class ItemSplitController {
             @RequestBody ItemRemainderRequest request
     ) {
         ItemParticipantsResponse response = itemSplitService.splitRemainder(itemId, request);
+
+        return ResponseEntity.status(GeneralSuccessCode.OK.getStatus())
+                .body(ApiResponse.onSuccess(GeneralSuccessCode.OK, response));
+    }
+
+    @PostMapping("/individual")
+    public ResponseEntity<ApiResponse<ItemParticipantsResponse>> splitIndividual(
+            @PathVariable Long tripId,
+            @PathVariable Long receiptId,
+            @PathVariable Long itemId,
+            @RequestBody ItemIndividualRequest request
+    ) {
+        ItemParticipantsResponse response = itemSplitService.splitIndividual(tripId, itemId, request);
 
         return ResponseEntity.status(GeneralSuccessCode.OK.getStatus())
                 .body(ApiResponse.onSuccess(GeneralSuccessCode.OK, response));

--- a/src/main/java/AIFinance/demo/receipt/dto/ItemIndividualRequest.java
+++ b/src/main/java/AIFinance/demo/receipt/dto/ItemIndividualRequest.java
@@ -1,0 +1,11 @@
+package AIFinance.demo.receipt.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ItemIndividualRequest {
+
+    private Long tripMemberId;
+}

--- a/src/main/java/AIFinance/demo/receipt/service/ItemSplitService.java
+++ b/src/main/java/AIFinance/demo/receipt/service/ItemSplitService.java
@@ -2,6 +2,7 @@ package AIFinance.demo.receipt.service;
 
 import AIFinance.demo.global.apiPayload.exception.GeneralException;
 import AIFinance.demo.global.exception.SplitErrorCode;
+import AIFinance.demo.receipt.dto.ItemIndividualRequest;
 import AIFinance.demo.receipt.dto.ItemParticipantsResponse;
 import AIFinance.demo.receipt.dto.ItemRemainderRequest;
 import AIFinance.demo.receipt.entity.ItemShare;
@@ -9,6 +10,8 @@ import AIFinance.demo.receipt.entity.ReceiptItem;
 import AIFinance.demo.receipt.entity.enums.SplitType;
 import AIFinance.demo.receipt.repository.ItemShareRepository;
 import AIFinance.demo.receipt.repository.ReceiptItemRepository;
+import AIFinance.demo.trip.entity.TripMember;
+import AIFinance.demo.trip.repository.TripMemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,6 +26,12 @@ public class ItemSplitService {
 
     private final ReceiptItemRepository receiptItemRepository;
     private final ItemShareRepository itemShareRepository;
+    private final TripMemberRepository tripMemberRepository;
+
+    private ReceiptItem getItem(Long itemId) {
+        return receiptItemRepository.findById(itemId)
+                .orElseThrow(() -> new GeneralException(SplitErrorCode.ITEM_NOT_FOUND));
+    }
 
     public ItemParticipantsResponse splitEqual(Long itemId) {
         ReceiptItem item = getItem(itemId);
@@ -78,8 +87,24 @@ public class ItemSplitService {
         return ItemParticipantsResponse.of(itemId, shares);
     }
 
-    private ReceiptItem getItem(Long itemId) {
-        return receiptItemRepository.findById(itemId)
-                .orElseThrow(() -> new GeneralException(SplitErrorCode.ITEM_NOT_FOUND));
+    public ItemParticipantsResponse splitIndividual(Long tripId, Long itemId, ItemIndividualRequest request) {
+        ReceiptItem item = getItem(itemId);
+
+        TripMember member = tripMemberRepository.findById(request.getTripMemberId())
+                .orElseThrow(() -> new GeneralException(SplitErrorCode.MEMBER_NOT_IN_TRIP));
+
+        if (!member.getTrip().getId().equals(tripId)) {
+            throw new GeneralException(SplitErrorCode.MEMBER_NOT_IN_TRIP);
+        }
+
+        itemShareRepository.deleteByItem_Id(itemId);
+
+        ItemShare share = ItemShare.of(item, member, item.getOriginalAmount());
+        itemShareRepository.save(share);
+
+        item.updateSplitType(SplitType.INDIVIDUAL);
+        item.updateRemainderMember(null);
+
+        return ItemParticipantsResponse.of(itemId, List.of(share));
     }
 }


### PR DESCRIPTION
## 관련 이슈
Closes #40 

## 작업 내용
<!-- 이 PR에서 진행한 작업을 간단히 설명해주세요. -->
- ItemSplitService에 splitIndividual() 추가
- SPLIT-05 API 구현
- 개인부담 전환 시 기존 remainderMember 초기화 로직 추가 

## AI 사용 여부
- [ ] 사용함
- [x] 사용하지 않음

### 사용한 AI 기능
<!-- AI를 사용한 경우에만 작성해주세요. -->

- AI 기능/도구:
- 사용 범위:
- 생성된 코드 직접 검토 여부: [ ] Yes
- AI 생성 코드를 수정했나요?: [ ] Yes / [ ] No

## 팀원이 확인해야 할 것

<!-- 리뷰 시 중점적으로 확인해야 할 내용이 있다면 작성해주세요. -->

-
