### PR TITLE
[CHORE] Swagger 설정 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ dependencies {
 	testAnnotationProcessor 'org.projectlombok:lombok'
 
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.1.0'
 
 	implementation 'io.jsonwebtoken:jjwt-api:0.13.0'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.13.0'

--- a/src/main/java/AIFinance/demo/global/config/SecurityConfig.java
+++ b/src/main/java/AIFinance/demo/global/config/SecurityConfig.java
@@ -40,6 +40,11 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.POST, "/api/v1/auth/login").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/v1/auth/check").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/v1/auth/refresh").permitAll()
+                        .requestMatchers(
+                                "/swagger-ui/**",
+                                "/swagger-ui.html",
+                                "/v3/api-docs/**"
+                        ).permitAll()
                         .requestMatchers("/api/v1/trips/*/receipts/**").permitAll()
                         .requestMatchers("/api/v1/**").authenticated()
                         .anyRequest().permitAll()

--- a/src/main/java/AIFinance/demo/global/config/SwaggerConfig.java
+++ b/src/main/java/AIFinance/demo/global/config/SwaggerConfig.java
@@ -1,0 +1,4 @@
+package AIFinance.demo.global.config;
+
+public class SwaggerConfig {
+}

--- a/src/main/java/AIFinance/demo/global/config/SwaggerConfig.java
+++ b/src/main/java/AIFinance/demo/global/config/SwaggerConfig.java
@@ -1,4 +1,48 @@
 package AIFinance.demo.global.config;
 
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
 public class SwaggerConfig {
+
+    private static final String JWT_SCHEME_NAME = "bearerAuth";
+
+    @Bean
+    public OpenAPI openAPI() {
+        SecurityRequirement securityRequirement =
+                new SecurityRequirement()
+                        .addList(JWT_SCHEME_NAME);
+
+        SecurityScheme securityScheme =
+                new SecurityScheme()
+                        .name(JWT_SCHEME_NAME)
+                        .type(SecurityScheme.Type.HTTP)
+                        .scheme("bearer")
+                        .bearerFormat("JWT");
+
+        Components components =
+                new Components()
+                        .addSecuritySchemes(
+                                JWT_SCHEME_NAME,
+                                securityScheme
+                        );
+
+        return new OpenAPI()
+                .info(
+                        new Info()
+                                .title("AI Finance API 명세서")
+                                .description(
+                                        "AI 영수증 기반 여행 정산 서비스 API 문서입니다."
+                                )
+                                .version("v1.0.0")
+                )
+                .addSecurityItem(securityRequirement)
+                .components(components);
+    }
 }


### PR DESCRIPTION
## 관련 이슈
Closes #35

## 작업 내용
<!-- 이 PR에서 진행한 작업을 간단히 설명해주세요. -->
- Swagger UI 및 OpenAPI 문서 설정 추가
- JWT Bearer 인증 스키마 추가
- Swagger 관련 경로를 Spring Security 허용 목록에 추가

## 주요 변경 사항
<!-- 주요 변경 사항을 작성해주세요. -->
- Springdoc OpenAPI 의존성 추가
- `SwaggerConfig` 추가
- `/swagger-ui/**`, `/v3/api-docs/**` 접근 허용

## 동작 흐름
<!-- 변경된 기능의 동작 흐름이나 처리 과정을 작성해주세요. 해당하지 않는 경우 삭제해주세요. -->
- 애플리케이션 실행 후 Swagger UI에 접속합니다.
- Authorize에서 JWT를 입력할 수 있습니다.
- 등록된 API 목록과 요청·응답을 확인할 수 있습니다.

## 응답 예시
<!-- API 응답이나 실행 결과가 있다면 작성해주세요. 해당하지 않는 경우 삭제해주세요. -->

```json
{
}
```

## AI 사용 여부
- [ ] 사용함
- [ ] 사용하지 않음

### 사용한 AI 기능
<!-- AI를 사용한 경우에만 작성해주세요. -->

- AI 기능/도구:
- 사용 범위:
- 생성된 코드 직접 검토 여부: [ ] Yes
- AI 생성 코드를 수정했나요?: [ ] Yes / [ ] No

## 팀원이 확인해야 할 것

<!-- 리뷰 시 중점적으로 확인해야 할 내용이 있다면 작성해주세요. -->

- Swagger UI 및 OpenAPI 문서 경로 접근 여부
- JWT Bearer 인증 설정 적용 여부