### PR TITLE
[FEAT] 참여자별 금액 조정 API 구현

### DIFF
--- a/src/main/java/AIFinance/demo/receipt/controller/ItemSplitController.java
+++ b/src/main/java/AIFinance/demo/receipt/controller/ItemSplitController.java
@@ -54,4 +54,17 @@ public class ItemSplitController {
         return ResponseEntity.status(GeneralSuccessCode.OK.getStatus())
                 .body(ApiResponse.onSuccess(GeneralSuccessCode.OK, response));
     }
+
+    @PutMapping("/custom")
+    public ResponseEntity<ApiResponse<ItemParticipantsResponse>> splitCustom(
+            @PathVariable Long tripId,
+            @PathVariable Long receiptId,
+            @PathVariable Long itemId,
+            @RequestBody ItemCustomRequest request
+    ) {
+        ItemParticipantsResponse response = itemSplitService.splitCustom(tripId, itemId, request);
+
+        return ResponseEntity.status(GeneralSuccessCode.OK.getStatus())
+                .body(ApiResponse.onSuccess(GeneralSuccessCode.OK, response));
+    }
 }

--- a/src/main/java/AIFinance/demo/receipt/dto/ItemCustomRequest.java
+++ b/src/main/java/AIFinance/demo/receipt/dto/ItemCustomRequest.java
@@ -1,0 +1,20 @@
+package AIFinance.demo.receipt.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class ItemCustomRequest {
+
+    private List<CustomShare> shares;
+
+    @Getter
+    @NoArgsConstructor
+    public static class CustomShare {
+        private Long tripMemberId;
+        private Long amount;
+    }
+}

--- a/src/main/java/AIFinance/demo/receipt/service/ItemSplitService.java
+++ b/src/main/java/AIFinance/demo/receipt/service/ItemSplitService.java
@@ -2,6 +2,7 @@ package AIFinance.demo.receipt.service;
 
 import AIFinance.demo.global.apiPayload.exception.GeneralException;
 import AIFinance.demo.global.exception.SplitErrorCode;
+import AIFinance.demo.receipt.dto.ItemCustomRequest;
 import AIFinance.demo.receipt.dto.ItemIndividualRequest;
 import AIFinance.demo.receipt.dto.ItemParticipantsResponse;
 import AIFinance.demo.receipt.dto.ItemRemainderRequest;
@@ -18,6 +19,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -107,4 +110,53 @@ public class ItemSplitService {
 
         return ItemParticipantsResponse.of(itemId, List.of(share));
     }
+
+    public ItemParticipantsResponse splitCustom(Long tripId, Long itemId, ItemCustomRequest request) {
+        List<ItemCustomRequest.CustomShare> customShares = request.getShares();
+        if (customShares == null || customShares.isEmpty()) {
+            throw new GeneralException(SplitErrorCode.NO_PARTICIPANT_SELECTED);
+        }
+
+        ReceiptItem item = getItem(itemId);
+
+        long total = customShares.stream()
+                .mapToLong(ItemCustomRequest.CustomShare::getAmount)
+                .sum();
+        if (total != item.getOriginalAmount()) {
+            throw new GeneralException(SplitErrorCode.AMOUNT_MISMATCH);
+        }
+
+        List<Long> tripMemberIds = customShares.stream()
+                .map(ItemCustomRequest.CustomShare::getTripMemberId)
+                .toList();
+        List<TripMember> members = tripMemberRepository.findAllById(tripMemberIds);
+        validateMembersBelongToTrip(members, tripMemberIds, tripId);
+
+        itemShareRepository.deleteByItem_Id(itemId);
+
+        Map<Long, TripMember> memberById = members.stream()
+                .collect(Collectors.toMap(TripMember::getId, member -> member));
+
+        List<ItemShare> shares = customShares.stream()
+                .map(cs -> ItemShare.of(item, memberById.get(cs.getTripMemberId()), cs.getAmount()))
+                .toList();
+        itemShareRepository.saveAll(shares);
+
+        item.updateSplitType(SplitType.CUSTOM);
+        item.updateRemainderMember(null);
+
+        return ItemParticipantsResponse.of(itemId, shares);
+    }
+
+    private void validateMembersBelongToTrip(List<TripMember> members, List<Long> requestedIds, Long tripId) {
+        if (members.size() != requestedIds.size()) {
+            throw new GeneralException(SplitErrorCode.MEMBER_NOT_IN_TRIP);
+        }
+        boolean allBelong = members.stream()
+                .allMatch(member -> member.getTrip().getId().equals(tripId));
+        if (!allBelong) {
+            throw new GeneralException(SplitErrorCode.MEMBER_NOT_IN_TRIP);
+        }
+    }
+
 }


### PR DESCRIPTION
## 관련 이슈
Closes #44 

## 작업 내용
<!-- 이 PR에서 진행한 작업을 간단히 설명해주세요. -->
- ItemSplitService에 splitCustom() 추가
- 참여자별 금액 조정 API 구현

## 주요 변경 사항
<!-- 주요 변경 사항을 작성해주세요. -->
- 입력 금액 합계가 originalAmount와 일치할 때 정상 저장 확인
- 합계 불일치 시 AMOUNT_MISMATCH(400) 반환 확인
- trip 소속이 아닌 회원 포함 시 MEMBER_NOT_IN_TRIP(400) 반환 확인
- 빈 shares 리스트 요청 시 NO_PARTICIPANT_SELECTED(400) 반환 확인
- 재호출 시 기존 ItemShare가 새 값으로 완전히 교체되는지 확인

## AI 사용 여부
- [ ] 사용함
- [ ] 사용하지 않음

### 사용한 AI 기능
<!-- AI를 사용한 경우에만 작성해주세요. -->

- AI 기능/도구:
- 사용 범위:
- 생성된 코드 직접 검토 여부: [ ] Yes
- AI 생성 코드를 수정했나요?: [ ] Yes / [ ] No

## 팀원이 확인해야 할 것

<!-- 리뷰 시 중점적으로 확인해야 할 내용이 있다면 작성해주세요. -->

-
