### PR TITLE
[FEAT] 부담자 미지정 상품 조회 API 구현

### DIFF
--- a/src/main/java/AIFinance/demo/receipt/controller/ReceiptSplitController.java
+++ b/src/main/java/AIFinance/demo/receipt/controller/ReceiptSplitController.java
@@ -1,4 +1,28 @@
 package AIFinance.demo.receipt.controller;
 
+import AIFinance.demo.global.apiPayload.ApiResponse;
+import AIFinance.demo.global.apiPayload.code.GeneralSuccessCode;
+import AIFinance.demo.receipt.dto.UnassignedItemsResponse;
+import AIFinance.demo.receipt.service.ItemSplitService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/trips/{tripId}/receipts/{receiptId}")
+@RequiredArgsConstructor
 public class ReceiptSplitController {
+
+    private final ItemSplitService itemSplitService;
+
+    @GetMapping("/unassigned-items")
+    public ResponseEntity<ApiResponse<UnassignedItemsResponse>> getUnassignedItems(
+            @PathVariable Long tripId,
+            @PathVariable Long receiptId
+    ) {
+        UnassignedItemsResponse response = itemSplitService.getUnassignedItems(receiptId);
+
+        return ResponseEntity.status(GeneralSuccessCode.OK.getStatus())
+                .body(ApiResponse.onSuccess(GeneralSuccessCode.OK, response));
+    }
 }

--- a/src/main/java/AIFinance/demo/receipt/controller/ReceiptSplitController.java
+++ b/src/main/java/AIFinance/demo/receipt/controller/ReceiptSplitController.java
@@ -1,0 +1,4 @@
+package AIFinance.demo.receipt.controller;
+
+public class ReceiptSplitController {
+}

--- a/src/main/java/AIFinance/demo/receipt/dto/UnassignedItemsResponse.java
+++ b/src/main/java/AIFinance/demo/receipt/dto/UnassignedItemsResponse.java
@@ -1,0 +1,4 @@
+package AIFinance.demo.receipt.dto;
+
+public class UnassignedItemsResponse {
+}

--- a/src/main/java/AIFinance/demo/receipt/dto/UnassignedItemsResponse.java
+++ b/src/main/java/AIFinance/demo/receipt/dto/UnassignedItemsResponse.java
@@ -1,4 +1,38 @@
 package AIFinance.demo.receipt.dto;
 
+import AIFinance.demo.receipt.entity.ReceiptItem;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
 public class UnassignedItemsResponse {
+
+    private Long receiptId;
+    private List<UnassignedItem> items;
+
+    public static UnassignedItemsResponse of(Long receiptId, List<ReceiptItem> items) {
+        List<UnassignedItem> unassignedItems = items.stream()
+                .map(item -> UnassignedItem.builder()
+                        .itemId(item.getId())
+                        .itemName(item.getItemName())
+                        .originalAmount(item.getOriginalAmount())
+                        .build())
+                .toList();
+
+        return UnassignedItemsResponse.builder()
+                .receiptId(receiptId)
+                .items(unassignedItems)
+                .build();
+    }
+
+    @Getter
+    @Builder
+    public static class UnassignedItem {
+        private Long itemId;
+        private String itemName;
+        private Long originalAmount;
+    }
 }

--- a/src/main/java/AIFinance/demo/receipt/repository/ReceiptItemRepository.java
+++ b/src/main/java/AIFinance/demo/receipt/repository/ReceiptItemRepository.java
@@ -3,11 +3,12 @@ package AIFinance.demo.receipt.repository;
 import AIFinance.demo.receipt.entity.ReceiptItem;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 
 public interface ReceiptItemRepository extends JpaRepository<ReceiptItem, Long> {
 
     Optional<ReceiptItem> findByIdAndReceipt_Id(Long itemId, Long receiptId);
-
+    List<ReceiptItem> findByReceipt_Id(Long receiptId);
 }

--- a/src/main/java/AIFinance/demo/receipt/service/ItemSplitService.java
+++ b/src/main/java/AIFinance/demo/receipt/service/ItemSplitService.java
@@ -2,10 +2,7 @@ package AIFinance.demo.receipt.service;
 
 import AIFinance.demo.global.apiPayload.exception.GeneralException;
 import AIFinance.demo.global.exception.SplitErrorCode;
-import AIFinance.demo.receipt.dto.ItemCustomRequest;
-import AIFinance.demo.receipt.dto.ItemIndividualRequest;
-import AIFinance.demo.receipt.dto.ItemParticipantsResponse;
-import AIFinance.demo.receipt.dto.ItemRemainderRequest;
+import AIFinance.demo.receipt.dto.*;
 import AIFinance.demo.receipt.entity.ItemShare;
 import AIFinance.demo.receipt.entity.ReceiptItem;
 import AIFinance.demo.receipt.entity.enums.SplitType;
@@ -159,4 +156,14 @@ public class ItemSplitService {
         }
     }
 
+    @Transactional(readOnly = true)
+    public UnassignedItemsResponse getUnassignedItems(Long receiptId) {
+        List<ReceiptItem> items = receiptItemRepository.findByReceipt_Id(receiptId);
+
+        List<ReceiptItem> unassignedItems = items.stream()
+                .filter(item -> !itemShareRepository.existsByItem_Id(item.getId()))
+                .toList();
+
+        return UnassignedItemsResponse.of(receiptId, unassignedItems);
+    }
 }


### PR DESCRIPTION
## 관련 이슈
Closes #46 

## 작업 내용
<!-- 이 PR에서 진행한 작업을 간단히 설명해주세요. -->
- ReceiptSplitController 신규 생성
- ItemSplitService에 getUnassignedItems() 추가
- ReceiptItemRepository에 findByReceipt_Id() 추가
- GET .../receipts/{receiptId}/unassigned-items 구현 (SPLIT-07)

## 확인사항
- 참여자가 전혀 지정 안 된 상품이 목록에 포함되는지 확인
- 참여자가 1명이라도 지정된 상품은 목록에서 제외되는지 확인
- 영수증에 상품이 하나도 없을 때 빈 배열 반환 확인

## AI 사용 여부
- [ ] 사용함
- [x] 사용하지 않음

### 사용한 AI 기능
<!-- AI를 사용한 경우에만 작성해주세요. -->

- AI 기능/도구:
- 사용 범위:
- 생성된 코드 직접 검토 여부: [ ] Yes
- AI 생성 코드를 수정했나요?: [ ] Yes / [ ] No
