### PR TITLE
[FEAT] 정산 마감 점검 API 구현

### DIFF
--- a/src/main/java/AIFinance/demo/receipt/controller/ItemSplitController.java
+++ b/src/main/java/AIFinance/demo/receipt/controller/ItemSplitController.java
@@ -6,6 +6,7 @@ import AIFinance.demo.receipt.dto.ItemIndividualRequest;
 import AIFinance.demo.receipt.dto.ItemParticipantsResponse;
 import AIFinance.demo.receipt.dto.ItemRemainderRequest;
 import AIFinance.demo.receipt.service.ItemSplitService;
+import AIFinance.demo.receipt.dto.ItemCustomRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;

--- a/src/main/java/AIFinance/demo/receipt/repository/ItemShareRepository.java
+++ b/src/main/java/AIFinance/demo/receipt/repository/ItemShareRepository.java
@@ -14,4 +14,6 @@ public interface ItemShareRepository extends JpaRepository<ItemShare, Long> {
     boolean existsByItem_Id(Long itemId);
 
     List<ItemShare> findByItem_IdInAndTripMember_Id(List<Long> itemIds, Long tripMemberId);
+
+    List<ItemShare> findByItem_IdIn(List<Long> itemIds);
 }

--- a/src/main/java/AIFinance/demo/settlement/controller/SettlementController.java
+++ b/src/main/java/AIFinance/demo/settlement/controller/SettlementController.java
@@ -1,15 +1,14 @@
 package AIFinance.demo.settlement.controller;
 
 import AIFinance.demo.global.apiPayload.ApiResponse;
+import AIFinance.demo.settlement.dto.SettlementCheckResponse;
 import AIFinance.demo.settlement.dto.SettlementResponse;
 import AIFinance.demo.settlement.exception.code.SettlementSuccessCode;
+import AIFinance.demo.settlement.service.SettlementCheckService;
 import AIFinance.demo.settlement.service.SettlementService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -17,6 +16,14 @@ import org.springframework.web.bind.annotation.RestController;
 public class SettlementController {
 
     private final SettlementService settlementService;
+    private final SettlementCheckService settlementCheckService;
+
+    @GetMapping("/check")
+    public ApiResponse<SettlementCheckResponse.Result> checkSettlement(@AuthenticationPrincipal Long userId, @PathVariable Long tripId) {
+        SettlementCheckResponse.Result response = settlementCheckService.checkSettlement(userId, tripId);
+
+        return ApiResponse.onSuccess(SettlementSuccessCode.SETTLEMENT_CHECKED, response);
+    }
 
     @PatchMapping("/complete")
     public ApiResponse<SettlementResponse.SettlementCompleted> completeSettlement(@AuthenticationPrincipal Long userId, @PathVariable Long tripId) {

--- a/src/main/java/AIFinance/demo/settlement/dto/SettlementCheckResponse.java
+++ b/src/main/java/AIFinance/demo/settlement/dto/SettlementCheckResponse.java
@@ -1,0 +1,30 @@
+package AIFinance.demo.settlement.dto;
+
+import AIFinance.demo.settlement.dto.enums.SettlementCheckIssueType;
+
+import java.util.List;
+
+public class SettlementCheckResponse {
+
+    private SettlementCheckResponse() {
+    }
+
+    public record Result(Long tripId, boolean readyToConfirm, Summary summary, List<Issue> issues) {
+        public static Result of(Long tripId, int receiptCount, Long totalAmount, List<Issue> issues) {
+            List<Issue> copiedIssues = List.copyOf(issues);
+
+            return new Result(tripId, copiedIssues.isEmpty(), new Summary(receiptCount, totalAmount, copiedIssues.size()), copiedIssues);
+        }
+    }
+
+    public record Summary(int receiptCount, Long totalAmount, int issueCount) {}
+
+    public record Issue(SettlementCheckIssueType type, Long receiptId, Long itemId, String message) {
+        public static Issue of(SettlementCheckIssueType type, Long receiptId, Long itemId, String message) {
+            return new Issue(type, receiptId, itemId, message);
+        }
+    }
+
+
+
+}

--- a/src/main/java/AIFinance/demo/settlement/dto/enums/SettlementCheckIssueType.java
+++ b/src/main/java/AIFinance/demo/settlement/dto/enums/SettlementCheckIssueType.java
@@ -1,0 +1,10 @@
+package AIFinance.demo.settlement.dto.enums;
+
+public enum SettlementCheckIssueType {
+    ANALYSIS_INCOMPLETE,
+    PAYER_UNASSIGNED,
+    ITEM_SHARE_UNASSIGNED,
+    SHARE_AMOUNT_MISMATCH,
+    RECEIPT_AMOUNT_MISMATCH,
+    DUPLICATE_REVIEW_REQUIRED
+}

--- a/src/main/java/AIFinance/demo/settlement/exception/code/SettlementErrorCode.java
+++ b/src/main/java/AIFinance/demo/settlement/exception/code/SettlementErrorCode.java
@@ -11,7 +11,7 @@ public enum SettlementErrorCode implements BaseErrorCode {
 
     TRIP_NOT_FOUND(HttpStatus.NOT_FOUND, "TRIP_NOT_FOUND", "여행방을 찾을 수 없습니다."),
 
-    INVALID_TRIP_STATUS(HttpStatus.CONFLICT, "INVALID_TRIP_STATUS", "정산 진행 중인 여행방에서만 처리할 수 있습니다."),
+    INVALID_TRIP_STATUS(HttpStatus.CONFLICT, "INVALID_TRIP_STATUS", "현재 여행 상태에서는 요청을 처리할 수 없습니다."),
 
     TRANSFER_NOT_FOUND(HttpStatus.NOT_FOUND, "TRANSFER_NOT_FOUND", "해당 여행방에서 송금 건을 찾을 수 없습니다."),
 
@@ -27,7 +27,7 @@ public enum SettlementErrorCode implements BaseErrorCode {
 
     SETTLEMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "SETTLEMENT_NOT_FOUND", "확정된 정산을 찾을 수 없습니다."),
 
-    TRIP_OWNER_REQUIRED(HttpStatus.FORBIDDEN, "TRIP_OWNER_REQUIRED", "여행방의 방장만 정산을 종료할 수 있습니다."),
+    TRIP_OWNER_REQUIRED(HttpStatus.FORBIDDEN, "TRIP_OWNER_REQUIRED", "여행방의 방장만 요청할 수 있습니다."),
 
     SETTLEMENT_ALREADY_COMPLETED(HttpStatus.CONFLICT, "SETTLEMENT_ALREADY_COMPLETED", "이미 종료된 정산입니다."),
 

--- a/src/main/java/AIFinance/demo/settlement/exception/code/SettlementSuccessCode.java
+++ b/src/main/java/AIFinance/demo/settlement/exception/code/SettlementSuccessCode.java
@@ -8,6 +8,9 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum SettlementSuccessCode implements BaseSuccessCode {
+
+    SETTLEMENT_CHECKED(HttpStatus.OK, "SETTLEMENT_CHECKED", "정산 마감 점검이 완료되었습니다."),
+
     TRANSFER_SENT(HttpStatus.OK, "TRANSFER_SENT", "송금 완료로 표시되었습니다."),
 
     TRANSFER_CONFIRMED(HttpStatus.OK, "TRANSFER_CONFIRMED", "입금이 확인되었습니다."),

--- a/src/main/java/AIFinance/demo/settlement/service/SettlementCheckService.java
+++ b/src/main/java/AIFinance/demo/settlement/service/SettlementCheckService.java
@@ -1,0 +1,162 @@
+package AIFinance.demo.settlement.service;
+
+import AIFinance.demo.receipt.entity.ItemShare;
+import AIFinance.demo.receipt.entity.Receipt;
+import AIFinance.demo.receipt.entity.ReceiptItem;
+import AIFinance.demo.receipt.entity.enums.ReceiptAnalysisStatus;
+import AIFinance.demo.receipt.entity.enums.ReceiptDuplicateStatus;
+import AIFinance.demo.receipt.entity.enums.ReceiptStatus;
+import AIFinance.demo.receipt.repository.ItemShareRepository;
+import AIFinance.demo.receipt.repository.ReceiptItemRepository;
+import AIFinance.demo.receipt.repository.ReceiptRepository;
+import AIFinance.demo.settlement.dto.SettlementCheckResponse;
+import AIFinance.demo.settlement.dto.enums.SettlementCheckIssueType;
+import AIFinance.demo.settlement.exception.SettlementException;
+import AIFinance.demo.settlement.exception.code.SettlementErrorCode;
+import AIFinance.demo.trip.entity.Trip;
+import AIFinance.demo.trip.entity.enums.TripStatus;
+import AIFinance.demo.trip.repository.TripRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class SettlementCheckService {
+
+    private final TripRepository tripRepository;
+    private final ReceiptRepository receiptRepository;
+    private final ReceiptItemRepository receiptItemRepository;
+    private final ItemShareRepository itemShareRepository;
+
+    public SettlementCheckResponse.Result checkSettlement(Long userId, Long tripId) {
+        Trip trip = getTrip(tripId);
+
+        validateOwner(trip, userId);
+        validateTripStatus(trip);
+
+        List<Receipt> receipts = getSettlementReceipts(tripId);
+        List<ReceiptItem> items = getReceiptItems(receipts);
+        List<ItemShare> shares = getItemShares(items);
+
+        Map<Long, List<ReceiptItem>> itemsByReceiptId = groupItemsByReceiptId(items);
+
+        Map<Long, List<ItemShare>> sharesByItemId = groupSharesByItemId(shares);
+
+        List<SettlementCheckResponse.Issue> issues = new ArrayList<>();
+
+        checkReceiptIssues(receipts, issues);
+        checkItemIssues(items, sharesByItemId, issues);
+        checkReceiptAmounts(receipts, itemsByReceiptId, issues);
+
+        long totalAmount = receipts.stream().map(Receipt::getTotalAmount).filter(Objects::nonNull).mapToLong(Long::longValue).sum();
+
+        return SettlementCheckResponse.Result.of(tripId, receipts.size(), totalAmount, issues);
+    }
+
+    private Trip getTrip(Long tripId) {
+        return tripRepository.findById(tripId)
+                .orElseThrow(() -> new SettlementException(SettlementErrorCode.TRIP_NOT_FOUND));
+    }
+
+    private List<Receipt> getSettlementReceipts(Long tripId) {
+        return receiptRepository
+                .findAllByTrip_IdAndStatusNot(tripId, ReceiptStatus.DELETED)
+                .stream()
+                .filter(receipt -> receipt.getDuplicateStatus() != ReceiptDuplicateStatus.DUPLICATE)
+                .toList();
+    }
+
+    private List<ReceiptItem> getReceiptItems(List<Receipt> receipts) {
+        List<Long> receiptIds = receipts.stream().map(Receipt::getId).toList();
+
+        if (receiptIds.isEmpty()) {
+            return List.of();
+        }
+
+        return receiptItemRepository.findByReceipt_IdIn(receiptIds);
+    }
+
+    private List<ItemShare> getItemShares(List<ReceiptItem> items) {
+        List<Long> itemIds = items.stream().map(ReceiptItem::getId).toList();
+
+        if (itemIds.isEmpty()) {
+            return List.of();
+        }
+
+        return itemShareRepository.findByItem_IdIn(itemIds);
+    }
+
+    private Map<Long, List<ReceiptItem>> groupItemsByReceiptId(List<ReceiptItem> items) {
+        return items.stream().collect(Collectors.groupingBy(item -> item.getReceipt().getId()));
+    }
+
+    private Map<Long, List<ItemShare>> groupSharesByItemId(List<ItemShare> shares) {
+        return shares.stream().collect(Collectors.groupingBy(share -> share.getItem().getId()));
+    }
+
+    private void checkReceiptIssues(List<Receipt> receipts, List<SettlementCheckResponse.Issue> issues) {
+        for (Receipt receipt : receipts) {
+
+            if (receipt.getAnalysisStatus() != ReceiptAnalysisStatus.SUCCESS) {
+                issues.add(SettlementCheckResponse.Issue.of(SettlementCheckIssueType.ANALYSIS_INCOMPLETE, receipt.getId(), null, "분석이 완료되지 않은 영수증입니다."));
+            }
+
+            if (receipt.getPayerMember() == null) {
+                issues.add(SettlementCheckResponse.Issue.of(SettlementCheckIssueType.PAYER_UNASSIGNED, receipt.getId(), null, "결제자가 지정되지 않은 영수증입니다."));
+            }
+
+            if (receipt.getDuplicateStatus() == ReceiptDuplicateStatus.PENDING) {
+                issues.add(SettlementCheckResponse.Issue.of(SettlementCheckIssueType.DUPLICATE_REVIEW_REQUIRED, receipt.getId(), null, "중복 여부 확인이 필요한 영수증입니다."));
+            }
+        }
+    }
+
+    private void checkItemIssues(List<ReceiptItem> items, Map<Long, List<ItemShare>> sharesByItemId, List<SettlementCheckResponse.Issue> issues) {
+        for (ReceiptItem item : items) {
+            List<ItemShare> itemShares = sharesByItemId.getOrDefault(item.getId(), List.of());
+
+            if (itemShares.isEmpty()) {
+                issues.add(SettlementCheckResponse.Issue.of(SettlementCheckIssueType.ITEM_SHARE_UNASSIGNED, item.getReceipt().getId(), item.getId(), "부담자가 지정되지 않은 상품입니다."));
+                continue;
+            }
+
+            long shareTotal = itemShares.stream().mapToLong(ItemShare::getShareAmount).sum();
+
+            if (shareTotal != item.getSettlementAmount()) {
+                issues.add(SettlementCheckResponse.Issue.of(SettlementCheckIssueType.SHARE_AMOUNT_MISMATCH, item.getReceipt().getId(), item.getId(), "상품 정산 금액과 부담 금액 합계가 일치하지 않습니다."));
+            }
+        }
+    }
+
+    private void checkReceiptAmounts(List<Receipt> receipts, Map<Long, List<ReceiptItem>> itemsByReceiptId, List<SettlementCheckResponse.Issue> issues) {
+        for (Receipt receipt : receipts) {
+            List<ReceiptItem> receiptItems = itemsByReceiptId.getOrDefault(receipt.getId(), List.of());
+
+            long itemTotal = receiptItems.stream().mapToLong(ReceiptItem::getSettlementAmount).sum();
+
+            if (!Objects.equals(receipt.getTotalAmount(), itemTotal)) {
+                issues.add(SettlementCheckResponse.Issue.of(SettlementCheckIssueType.RECEIPT_AMOUNT_MISMATCH, receipt.getId(), null, "영수증 총액과 상품 정산 금액 합계가 일치하지 않습니다."));
+            }
+        }
+    }
+
+    private void validateOwner(Trip trip, Long userId) {
+        if (!Objects.equals(trip.getOwner().getId(), userId)) {
+            throw new SettlementException(SettlementErrorCode.TRIP_OWNER_REQUIRED);
+        }
+    }
+
+    private void validateTripStatus(Trip trip) {
+        if (trip.getStatus() != TripStatus.ACTIVE) {
+            throw new SettlementException(SettlementErrorCode.INVALID_TRIP_STATUS);
+        }
+    }
+}


### PR DESCRIPTION
## 관련 이슈
Closes #50

## 작업 내용
<!-- 이 PR에서 진행한 작업을 간단히 설명해주세요. -->
- 정산 확정 전 미완료 항목을 점검하는 API를 구현했습니다.
- 정산 확정 가능 여부와 문제 목록을 반환합니다.

## 주요 변경 사항
<!-- 주요 변경 사항을 작성해주세요. -->
- 여행방 및 방장 권한 검증
- 여행 상태 검증
- 분석 미완료 및 결제자 미지정 영수증 확인
- 중복 검토가 필요한 영수증 확인
- 부담자 미지정 상품 확인
- 상품 정산 금액과 부담액 합계 검증
- 영수증 총액과 상품 정산 금액 합계 검증
- 상품 부담 내역 일괄 조회 Repository 메서드 추가

- 직접 분할 API의 DTO import 누락 수정

## 동작 흐름
<!-- 변경된 기능의 동작 흐름이나 처리 과정을 작성해주세요. 해당하지 않는 경우 삭제해주세요. -->
- 방장이 정산 마감 점검을 요청합니다.
- 정산 후보 영수증과 상품, 부담 내역을 조회합니다.
- 미완료 항목과 금액 불일치를 검사합니다.
- 문제가 없으면 `readyToConfirm`을 `true`로 반환합니다.
- 문제가 있으면 `readyToConfirm`을 `false`로 반환하고 문제 목록을 제공합니다.

## AI 사용 여부
- [ ] 사용함
- [ ] 사용하지 않음

### 사용한 AI 기능
<!-- AI를 사용한 경우에만 작성해주세요. -->

- AI 기능/도구:
- 사용 범위:
- 생성된 코드 직접 검토 여부: [ ] Yes
- AI 생성 코드를 수정했나요?: [ ] Yes / [ ] No

## 팀원이 확인해야 할 것

<!-- 리뷰 시 중점적으로 확인해야 할 내용이 있다면 작성해주세요. -->

-
