### PR TITLE
[FEAT] 정산 확정 API 구현

### DIFF
--- a/src/main/java/AIFinance/demo/receipt/entity/Receipt.java
+++ b/src/main/java/AIFinance/demo/receipt/entity/Receipt.java
@@ -95,6 +95,10 @@ public class Receipt extends BaseEntity {
         }
     }
 
+    public void confirm() {
+        this.status = ReceiptStatus.CONFIRMED;
+    }
+
     public void delete() {
         this.status = ReceiptStatus.DELETED;
     }

--- a/src/main/java/AIFinance/demo/settlement/controller/SettlementController.java
+++ b/src/main/java/AIFinance/demo/settlement/controller/SettlementController.java
@@ -5,6 +5,7 @@ import AIFinance.demo.settlement.dto.SettlementCheckResponse;
 import AIFinance.demo.settlement.dto.SettlementResponse;
 import AIFinance.demo.settlement.exception.code.SettlementSuccessCode;
 import AIFinance.demo.settlement.service.SettlementCheckService;
+import AIFinance.demo.settlement.service.SettlementConfirmService;
 import AIFinance.demo.settlement.service.SettlementService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -17,12 +18,20 @@ public class SettlementController {
 
     private final SettlementService settlementService;
     private final SettlementCheckService settlementCheckService;
+    private final SettlementConfirmService settlementConfirmService;
 
     @GetMapping("/check")
     public ApiResponse<SettlementCheckResponse.Result> checkSettlement(@AuthenticationPrincipal Long userId, @PathVariable Long tripId) {
         SettlementCheckResponse.Result response = settlementCheckService.checkSettlement(userId, tripId);
 
         return ApiResponse.onSuccess(SettlementSuccessCode.SETTLEMENT_CHECKED, response);
+    }
+
+    @PutMapping
+    public ApiResponse<SettlementResponse.SettlementConfirmed> confirmSettlement(@AuthenticationPrincipal Long userId, @PathVariable Long tripId) {
+        SettlementResponse.SettlementConfirmed response = settlementConfirmService.confirmSettlement(userId, tripId);
+
+        return ApiResponse.onSuccess(SettlementSuccessCode.SETTLEMENT_CONFIRMED, response);
     }
 
     @PatchMapping("/complete")

--- a/src/main/java/AIFinance/demo/settlement/dto/SettlementResponse.java
+++ b/src/main/java/AIFinance/demo/settlement/dto/SettlementResponse.java
@@ -11,6 +11,19 @@ public class SettlementResponse {
 
     private SettlementResponse() {}
 
+    public record SettlementConfirmed(Long settlementId, Long tripId, SettlementStatus status, Long totalAmount, int transferCount, LocalDateTime confirmedAt) {
+        public static SettlementConfirmed from(Settlement settlement, int transferCount) {
+            return new SettlementConfirmed(
+                    settlement.getId(),
+                    settlement.getTrip().getId(),
+                    settlement.getStatus(),
+                    settlement.getTotalAmount(),
+                    transferCount,
+                    settlement.getConfirmedAt()
+            );
+        }
+    }
+
     public record TransferSent(Long transferId, Long settlementId, SettlementTransferStatus status, LocalDateTime sentAt) {
         public static TransferSent from(SettlementTransfer transfer){
             return new TransferSent(

--- a/src/main/java/AIFinance/demo/settlement/exception/code/SettlementErrorCode.java
+++ b/src/main/java/AIFinance/demo/settlement/exception/code/SettlementErrorCode.java
@@ -31,7 +31,11 @@ public enum SettlementErrorCode implements BaseErrorCode {
 
     SETTLEMENT_ALREADY_COMPLETED(HttpStatus.CONFLICT, "SETTLEMENT_ALREADY_COMPLETED", "이미 종료된 정산입니다."),
 
-    INCOMPLETE_TRANSFERS(HttpStatus.CONFLICT, "INCOMPLETE_TRANSFERS", "완료되지 않은 송금 건이 남아 있습니다.");
+    INCOMPLETE_TRANSFERS(HttpStatus.CONFLICT, "INCOMPLETE_TRANSFERS", "완료되지 않은 송금 건이 남아 있습니다."),
+
+    SETTLEMENT_NOT_READY(HttpStatus.CONFLICT, "SETTLEMENT_NOT_READY", "미완료 항목이 남아 있어 정산을 확정할 수 없습니다."),
+
+    SETTLEMENT_ALREADY_CONFIRMED(HttpStatus.CONFLICT, "SETTLEMENT_ALREADY_CONFIRMED", "이미 확정된 정산입니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/AIFinance/demo/settlement/exception/code/SettlementSuccessCode.java
+++ b/src/main/java/AIFinance/demo/settlement/exception/code/SettlementSuccessCode.java
@@ -15,7 +15,9 @@ public enum SettlementSuccessCode implements BaseSuccessCode {
 
     TRANSFER_CONFIRMED(HttpStatus.OK, "TRANSFER_CONFIRMED", "입금이 확인되었습니다."),
 
-    SETTLEMENT_COMPLETED(HttpStatus.OK, "SETTLEMENT_COMPLETED", "정산이 종료되었습니다.");
+    SETTLEMENT_COMPLETED(HttpStatus.OK, "SETTLEMENT_COMPLETED", "정산이 종료되었습니다."),
+
+    SETTLEMENT_CONFIRMED(HttpStatus.OK, "SETTLEMENT_CONFIRMED", "정산이 확정되었습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/AIFinance/demo/settlement/repository/SettlementRepository.java
+++ b/src/main/java/AIFinance/demo/settlement/repository/SettlementRepository.java
@@ -7,4 +7,5 @@ import java.util.Optional;
 
 public interface SettlementRepository extends JpaRepository<Settlement, Long> {
     Optional<Settlement> findByTrip_Id(Long tripId);
+    boolean existsByTrip_Id(Long tripId);
 }

--- a/src/main/java/AIFinance/demo/settlement/service/SettlementConfirmService.java
+++ b/src/main/java/AIFinance/demo/settlement/service/SettlementConfirmService.java
@@ -1,0 +1,128 @@
+package AIFinance.demo.settlement.service;
+
+import AIFinance.demo.receipt.entity.ItemShare;
+import AIFinance.demo.receipt.entity.Receipt;
+import AIFinance.demo.receipt.entity.ReceiptItem;
+import AIFinance.demo.receipt.entity.enums.ReceiptDuplicateStatus;
+import AIFinance.demo.receipt.entity.enums.ReceiptStatus;
+import AIFinance.demo.receipt.repository.ItemShareRepository;
+import AIFinance.demo.receipt.repository.ReceiptItemRepository;
+import AIFinance.demo.receipt.repository.ReceiptRepository;
+import AIFinance.demo.settlement.dto.SettlementCheckResponse;
+import AIFinance.demo.settlement.dto.SettlementResponse;
+import AIFinance.demo.settlement.entity.Settlement;
+import AIFinance.demo.settlement.entity.SettlementTransfer;
+import AIFinance.demo.settlement.exception.SettlementException;
+import AIFinance.demo.settlement.exception.code.SettlementErrorCode;
+import AIFinance.demo.settlement.repository.SettlementRepository;
+import AIFinance.demo.settlement.repository.SettlementTransferRepository;
+import AIFinance.demo.trip.entity.Trip;
+import AIFinance.demo.trip.entity.TripMember;
+import AIFinance.demo.trip.entity.enums.TripMemberStatus;
+import AIFinance.demo.trip.entity.enums.TripStatus;
+import AIFinance.demo.trip.repository.TripMemberRepository;
+import AIFinance.demo.trip.repository.TripRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Objects;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class SettlementConfirmService {
+    private final TripRepository tripRepository;
+    private final TripMemberRepository tripMemberRepository;
+    private final ReceiptRepository receiptRepository;
+    private final ReceiptItemRepository receiptItemRepository;
+    private final ItemShareRepository itemShareRepository;
+    private final SettlementRepository settlementRepository;
+    private final SettlementTransferRepository settlementTransferRepository;
+    private final SettlementCheckService settlementCheckService;
+    private final SettlementTransferCalculator transferCalculator;
+
+    @Transactional
+    public SettlementResponse.SettlementConfirmed confirmSettlement(Long userId, Long tripId) {
+        Trip trip = getTripForUpdate(tripId);
+
+        validateOwner(trip, userId);
+        validateNotConfirmed(tripId);
+        validateTripStatus(trip);
+
+        SettlementCheckResponse.Result checkResult = settlementCheckService.checkSettlement(userId, tripId);
+
+        if (!checkResult.readyToConfirm()) {
+            throw new SettlementException(SettlementErrorCode.SETTLEMENT_NOT_READY);
+        }
+
+        List<Receipt> receipts = getSettlementReceipts(tripId);
+        List<ReceiptItem> items = getReceiptItems(receipts);
+        List<ItemShare> shares = getItemShares(items);
+        List<TripMember> members = tripMemberRepository.findAllByTrip_IdAndStatus(tripId, TripMemberStatus.ACTIVE);
+
+        TripMember confirmer = findConfirmer(members, userId);
+
+        Settlement settlement = settlementRepository.save(Settlement.create(trip, confirmer, checkResult.summary().totalAmount()));
+
+        List<SettlementTransfer> transfers = transferCalculator.calculate(settlement, members, receipts, shares);
+
+        settlementTransferRepository.saveAll(transfers);
+
+        receipts.forEach(Receipt::confirm);
+        trip.startSettlement();
+
+        return SettlementResponse.SettlementConfirmed.from(settlement, transfers.size());
+
+    }
+
+    private Trip getTripForUpdate(Long tripId) {
+        return tripRepository.findByIdForUpdate(tripId)
+                .orElseThrow(() -> new SettlementException(SettlementErrorCode.TRIP_NOT_FOUND));
+    }
+
+    private List<Receipt> getSettlementReceipts(Long tripId) {
+        return receiptRepository.findAllByTrip_IdAndStatusNot(tripId, ReceiptStatus.DELETED)
+                .stream()
+                .filter(receipt -> receipt.getDuplicateStatus() != ReceiptDuplicateStatus.DUPLICATE)
+                .toList();
+    }
+
+    private List<ReceiptItem> getReceiptItems(List<Receipt> receipts) {
+        List<Long> receiptIds = receipts.stream().map(Receipt::getId).toList();
+
+        return receiptIds.isEmpty() ? List.of() : receiptItemRepository.findByReceipt_IdIn(receiptIds);
+    }
+
+    private  List<ItemShare> getItemShares(List<ReceiptItem> items) {
+        List<Long> itemIds = items.stream().map(ReceiptItem::getId).toList();
+
+        return itemIds.isEmpty() ? List.of() : itemShareRepository.findByItem_IdIn(itemIds);
+    }
+
+    private TripMember findConfirmer(List<TripMember> members, Long userId) {
+        return members.stream()
+                .filter(member -> Objects.equals(member.getUser().getId(), userId))
+                .findFirst()
+                .orElseThrow(() -> new SettlementException(SettlementErrorCode.TRIP_OWNER_REQUIRED));
+    }
+
+    private void validateOwner(Trip trip, Long userId) {
+        if (!Objects.equals(trip.getOwner().getId(), userId)) {
+            throw new SettlementException(SettlementErrorCode.TRIP_OWNER_REQUIRED);
+        }
+    }
+
+    private void validateNotConfirmed(Long tripId) {
+        if (settlementRepository.existsByTrip_Id(tripId)) {
+            throw new SettlementException(SettlementErrorCode.SETTLEMENT_ALREADY_CONFIRMED);
+        }
+    }
+
+    private void validateTripStatus(Trip trip) {
+        if (trip.getStatus() != TripStatus.ACTIVE) {
+            throw new SettlementException(SettlementErrorCode.INVALID_TRIP_STATUS);
+        }
+    }
+}

--- a/src/main/java/AIFinance/demo/settlement/service/SettlementTransferCalculator.java
+++ b/src/main/java/AIFinance/demo/settlement/service/SettlementTransferCalculator.java
@@ -1,0 +1,113 @@
+package AIFinance.demo.settlement.service;
+
+import AIFinance.demo.receipt.entity.ItemShare;
+import AIFinance.demo.receipt.entity.Receipt;
+import AIFinance.demo.settlement.entity.Settlement;
+import AIFinance.demo.settlement.entity.SettlementTransfer;
+import AIFinance.demo.settlement.exception.SettlementException;
+import AIFinance.demo.settlement.exception.code.SettlementErrorCode;
+import AIFinance.demo.trip.entity.TripMember;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Component
+public class SettlementTransferCalculator {
+
+    public List<SettlementTransfer> calculate(Settlement settlement, List<TripMember> members, List<Receipt> receipts, List<ItemShare> shares) {
+        Map<Long, TripMember> membersById = members.stream().collect(Collectors.toMap(TripMember::getId, Function.identity()));
+
+        Map<Long, Long> balances = initializeBalances(members);
+        addPayments(balances, membersById, receipts);
+        subtractBurdens(balances, membersById, shares);
+        validateBalanceTotal(balances);
+
+        return createTransfers(settlement, membersById, balances);
+    }
+
+    private Map<Long, Long> initializeBalances(List<TripMember> members) {
+        Map<Long, Long> balances = new HashMap<>();
+
+        for (TripMember member : members) {
+            balances.put(member.getId(), 0L);
+        }
+        return balances;
+    }
+
+    private void addPayments(Map<Long, Long> balances, Map<Long, TripMember> membersById, List<Receipt> receipts) {
+        for (Receipt receipt : receipts) {
+            Long payerId = receipt.getPayerMember().getId();
+
+            validateActiveMember(membersById, payerId);
+            balances.merge(payerId, receipt.getTotalAmount(), Long::sum);
+
+        }
+    }
+
+    private void subtractBurdens(Map<Long, Long> balances, Map<Long, TripMember> membersById, List<ItemShare> shares) {
+        for (ItemShare share : shares) {
+            Long memberId = share.getTripMember().getId();
+            validateActiveMember(membersById, memberId);
+            balances.merge(memberId, -share.getShareAmount(), Long::sum);
+        }
+    }
+
+    private void validateActiveMember(Map<Long, TripMember> membersById, Long memberId) {
+        if (!membersById.containsKey(memberId)) {
+            throw new SettlementException(SettlementErrorCode.SETTLEMENT_NOT_READY);
+        }
+    }
+
+    private void validateBalanceTotal(Map<Long, Long> balances) {
+        long total = balances.values().stream().mapToLong(Long::longValue).sum();
+
+        if (total != 0L) {
+            throw new SettlementException(SettlementErrorCode.SETTLEMENT_NOT_READY);
+        }
+    }
+
+    private List<SettlementTransfer> createTransfers(Settlement settlement, Map<Long, TripMember> membersById, Map<Long, Long> balances) {
+        List<Long> senders = findMemberIdsByBalance(balances, false);
+        List<Long> receivers = findMemberIdsByBalance(balances, true);
+        List<SettlementTransfer> transfers = new ArrayList<>();
+
+        int senderIndex = 0;
+        int receiverIndex = 0;
+
+        while (senderIndex < senders.size() && receiverIndex < receivers.size()) {
+            Long senderId = senders.get(senderIndex);
+            Long receiverId = receivers.get(receiverIndex);
+
+            long amount = Math.min(-balances.get(senderId), balances.get(receiverId));
+
+            transfers.add(SettlementTransfer.create(settlement, membersById.get(senderId), membersById.get(receiverId), amount));
+
+            balances.merge(senderId, amount, Long::sum);
+            balances.merge(receiverId, -amount, Long::sum);
+
+            if (balances.get(senderId) == 0L) {
+                senderIndex++;
+            }
+
+            if (balances.get(receiverId) == 0L) {
+                receiverIndex++;
+            }
+        }
+
+        return transfers;
+    }
+
+    private List<Long> findMemberIdsByBalance(Map<Long, Long> balances, boolean positive) {
+        return balances.entrySet().stream()
+                .filter(entry -> positive ? entry.getValue() > 0L : entry.getValue() < 0L)
+                .map(Map.Entry::getKey)
+                .sorted()
+                .toList();
+    }
+
+}

--- a/src/main/java/AIFinance/demo/trip/entity/Trip.java
+++ b/src/main/java/AIFinance/demo/trip/entity/Trip.java
@@ -45,6 +45,10 @@ public class Trip extends BaseEntity {
     @Column(name = "invite_expires_at")
     private LocalDateTime inviteExpiresAt;
 
+    public void startSettlement() {
+        this.status = TripStatus.SETTLING;
+    }
+
     public void completeSettlement() {
         this.status = TripStatus.COMPLETED;
     }

--- a/src/main/java/AIFinance/demo/trip/repository/TripRepository.java
+++ b/src/main/java/AIFinance/demo/trip/repository/TripRepository.java
@@ -1,10 +1,18 @@
 package AIFinance.demo.trip.repository;
 
 import AIFinance.demo.trip.entity.Trip;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface TripRepository extends JpaRepository<Trip, Long> {
     Optional<Trip> findByInviteCode(String inviteCode);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select t from Trip t where t.id = :tripId")
+    Optional<Trip> findByIdForUpdate(@Param("tripId") Long tripId);
 }


### PR DESCRIPTION
## 관련 이슈
Closes #52

## 작업 내용
<!-- 이 PR에서 진행한 작업을 간단히 설명해주세요. -->
- 방장이 여행 정산을 최종 확정하는 API를 구현했습니다.
- 참여자별 결제액과 부담액을 기준으로 정산 차액을 계산합니다.
- 계산된 차액을 기준으로 최종 송금 관계를 생성합니다.

## 주요 변경 사항
<!-- 주요 변경 사항을 작성해주세요. -->
- 정산 확정 전 마감 점검 결과 재검증
- 참여자별 정산 차액 계산
- 송금자와 수취인 간 송금 관계 생성
- Settlement 및 SettlementTransfer 저장
- 정산 대상 영수증 상태를 CONFIRMED로 변경
- 여행 상태를 ACTIVE에서 SETTLING으로 변경
- 중복 정산 요청 방지를 위한 여행방 잠금 처리
- 정산 확정 응답 DTO 및 성공·예외 코드 추가

## 동작 흐름
<!-- 변경된 기능의 동작 흐름이나 처리 과정을 작성해주세요. 해당하지 않는 경우 삭제해주세요. -->
- 여행방을 잠금 상태로 조회합니다.
- 방장 권한, 여행 상태, 기존 정산 존재 여부를 확인합니다.
- 정산 마감 점검을 다시 수행합니다.
- 참여자별 결제액에서 부담액을 차감해 차액을 계산합니다.
- 차액이 음수인 참여자와 양수인 참여자 사이의 송금 관계를 생성합니다.
- 정산과 송금 내역을 저장하고 여행 및 영수증 상태를 변경합니다.

## 응답 예시
<!-- API 응답이나 실행 결과가 있다면 작성해주세요. 해당하지 않는 경우 삭제해주세요. -->

```json
{
  "isSuccess": true,
  "code": "SETTLEMENT_CONFIRMED",
  "message": "정산이 확정되었습니다.",
  "result": {
    "settlementId": 1,
    "tripId": 1,
    "status": "CONFIRMED",
    "totalAmount": 194000,
    "transferCount": 3,
    "confirmedAt": "2026-09-03T15:30:00"
  }
}
```

## AI 사용 여부
- [ ] 사용함
- [ ] 사용하지 않음

### 사용한 AI 기능
<!-- AI를 사용한 경우에만 작성해주세요. -->

- AI 기능/도구:
- 사용 범위:
- 생성된 코드 직접 검토 여부: [ ] Yes
- AI 생성 코드를 수정했나요?: [ ] Yes / [ ] No

## 팀원이 확인해야 할 것

<!-- 리뷰 시 중점적으로 확인해야 할 내용이 있다면 작성해주세요. -->

-
