### PR TITLE
[FEAT] 정산 결과 조회 API 구현

### DIFF
--- a/src/main/java/AIFinance/demo/receipt/repository/ReceiptRepository.java
+++ b/src/main/java/AIFinance/demo/receipt/repository/ReceiptRepository.java
@@ -12,5 +12,8 @@ public interface ReceiptRepository extends JpaRepository<Receipt, Long> {
     Optional<Receipt> findByIdAndTrip_Id(Long receiptId, Long tripId);
 
     List<Receipt> findAllByTrip_IdAndStatusNot(Long tripId, ReceiptStatus status);
+
     List<Receipt> findByTrip_Id(Long tripId);
+
+    List<Receipt> findAllByTrip_IdAndStatus(Long tripId, ReceiptStatus status);
 }

--- a/src/main/java/AIFinance/demo/settlement/controller/SettlementController.java
+++ b/src/main/java/AIFinance/demo/settlement/controller/SettlementController.java
@@ -3,9 +3,11 @@ package AIFinance.demo.settlement.controller;
 import AIFinance.demo.global.apiPayload.ApiResponse;
 import AIFinance.demo.settlement.dto.SettlementCheckResponse;
 import AIFinance.demo.settlement.dto.SettlementResponse;
+import AIFinance.demo.settlement.dto.SettlementResultResponse;
 import AIFinance.demo.settlement.exception.code.SettlementSuccessCode;
 import AIFinance.demo.settlement.service.SettlementCheckService;
 import AIFinance.demo.settlement.service.SettlementConfirmService;
+import AIFinance.demo.settlement.service.SettlementResultService;
 import AIFinance.demo.settlement.service.SettlementService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -19,12 +21,21 @@ public class SettlementController {
     private final SettlementService settlementService;
     private final SettlementCheckService settlementCheckService;
     private final SettlementConfirmService settlementConfirmService;
+    private final SettlementResultService settlementResultService;
 
     @GetMapping("/check")
     public ApiResponse<SettlementCheckResponse.Result> checkSettlement(@AuthenticationPrincipal Long userId, @PathVariable Long tripId) {
         SettlementCheckResponse.Result response = settlementCheckService.checkSettlement(userId, tripId);
 
         return ApiResponse.onSuccess(SettlementSuccessCode.SETTLEMENT_CHECKED, response);
+    }
+
+    @GetMapping
+    public ApiResponse<SettlementResultResponse.Result> getSettlementResult(@AuthenticationPrincipal Long userId, @PathVariable Long tripId
+    ) {
+        SettlementResultResponse.Result response = settlementResultService.getSettlementResult(userId, tripId);
+
+        return ApiResponse.onSuccess(SettlementSuccessCode.SETTLEMENT_RESULT_RETRIEVED, response);
     }
 
     @PutMapping

--- a/src/main/java/AIFinance/demo/settlement/dto/SettlementResultResponse.java
+++ b/src/main/java/AIFinance/demo/settlement/dto/SettlementResultResponse.java
@@ -1,0 +1,67 @@
+package AIFinance.demo.settlement.dto;
+
+import AIFinance.demo.settlement.entity.Settlement;
+import AIFinance.demo.settlement.entity.SettlementTransfer;
+import AIFinance.demo.settlement.entity.enums.SettlementStatus;
+import AIFinance.demo.settlement.entity.enums.SettlementTransferStatus;
+import AIFinance.demo.trip.entity.TripMember;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class SettlementResultResponse {
+    private SettlementResultResponse() {}
+
+    public record Result(
+            Long settlementId,
+            Long tripId,
+            SettlementStatus status,
+            Long totalAmount,
+            LocalDateTime confirmedAt,
+            LocalDateTime completedAt,
+            List<Participant> participants,
+            List<Transfer> transfers) {
+        public static Result of(Settlement settlement, List<Participant> participants, List<Transfer> transfers) {
+            return new Result(
+                    settlement.getId(),
+                    settlement.getTrip().getId(),
+                    settlement.getStatus(),
+                    settlement.getTotalAmount(),
+                    settlement.getConfirmedAt(),
+                    settlement.getCompletedAt(),
+                    List.copyOf(participants),
+                    List.copyOf(transfers)
+            );
+        }
+    }
+
+    public record Participant(Long tripMemberId, Long userId, String nickname, Long paymentAmount, Long shareAmount, Long differenceAmount){
+        public static Participant of(TripMember member, Long paymentAmount, Long shareAmount) {
+            return new Participant(member.getId(), member.getUser().getId(), member.getUser().getNickname(), paymentAmount, shareAmount, paymentAmount - shareAmount);
+        }
+    }
+
+    public record Transfer(
+            Long transferId,
+            Long senderMemberId,
+            String senderNickname,
+            Long receiverMemberId,
+            String receiverNickname,
+            Long amount,
+            SettlementTransferStatus status,
+            LocalDateTime sentAt,
+            LocalDateTime confirmedAt) {
+        public static Transfer from(SettlementTransfer transfer) {
+            return new Transfer(
+                    transfer.getId(),
+                    transfer.getSenderMember().getId(),
+                    transfer.getSenderMember().getUser().getNickname(),
+                    transfer.getReceiverMember().getId(),
+                    transfer.getReceiverMember().getUser().getNickname(),
+                    transfer.getAmount(),
+                    transfer.getStatus(),
+                    transfer.getSentAt(),
+                    transfer.getConfirmedAt());
+        }
+    }
+}

--- a/src/main/java/AIFinance/demo/settlement/exception/code/SettlementErrorCode.java
+++ b/src/main/java/AIFinance/demo/settlement/exception/code/SettlementErrorCode.java
@@ -29,6 +29,8 @@ public enum SettlementErrorCode implements BaseErrorCode {
 
     TRIP_OWNER_REQUIRED(HttpStatus.FORBIDDEN, "TRIP_OWNER_REQUIRED", "여행방의 방장만 요청할 수 있습니다."),
 
+    TRIP_MEMBER_REQUIRED(HttpStatus.FORBIDDEN, "TRIP_MEMBER_REQUIRED", "해당 여행방의 참여자만 요청할 수 있습니다."),
+
     SETTLEMENT_ALREADY_COMPLETED(HttpStatus.CONFLICT, "SETTLEMENT_ALREADY_COMPLETED", "이미 종료된 정산입니다."),
 
     INCOMPLETE_TRANSFERS(HttpStatus.CONFLICT, "INCOMPLETE_TRANSFERS", "완료되지 않은 송금 건이 남아 있습니다."),

--- a/src/main/java/AIFinance/demo/settlement/exception/code/SettlementSuccessCode.java
+++ b/src/main/java/AIFinance/demo/settlement/exception/code/SettlementSuccessCode.java
@@ -11,13 +11,17 @@ public enum SettlementSuccessCode implements BaseSuccessCode {
 
     SETTLEMENT_CHECKED(HttpStatus.OK, "SETTLEMENT_CHECKED", "정산 마감 점검이 완료되었습니다."),
 
+    SETTLEMENT_CONFIRMED(HttpStatus.OK, "SETTLEMENT_CONFIRMED", "정산이 확정되었습니다."),
+
+    SETTLEMENT_RESULT_RETRIEVED(HttpStatus.OK, "SETTLEMENT_RESULT_RETRIEVED", "정산 결과를 조회했습니다."),
+
     TRANSFER_SENT(HttpStatus.OK, "TRANSFER_SENT", "송금 완료로 표시되었습니다."),
 
     TRANSFER_CONFIRMED(HttpStatus.OK, "TRANSFER_CONFIRMED", "입금이 확인되었습니다."),
 
-    SETTLEMENT_COMPLETED(HttpStatus.OK, "SETTLEMENT_COMPLETED", "정산이 종료되었습니다."),
+    SETTLEMENT_COMPLETED(HttpStatus.OK, "SETTLEMENT_COMPLETED", "정산이 종료되었습니다.");
 
-    SETTLEMENT_CONFIRMED(HttpStatus.OK, "SETTLEMENT_CONFIRMED", "정산이 확정되었습니다.");
+
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/AIFinance/demo/settlement/repository/SettlementTransferRepository.java
+++ b/src/main/java/AIFinance/demo/settlement/repository/SettlementTransferRepository.java
@@ -4,6 +4,7 @@ import AIFinance.demo.settlement.entity.SettlementTransfer;
 import AIFinance.demo.settlement.entity.enums.SettlementTransferStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface SettlementTransferRepository extends JpaRepository<SettlementTransfer, Long> {
@@ -12,4 +13,5 @@ public interface SettlementTransferRepository extends JpaRepository<SettlementTr
 
     boolean existsBySettlement_IdAndStatusNot(Long settlementId, SettlementTransferStatus status);
 
+    List<SettlementTransfer> findAllBySettlement_IdOrderByIdAsc(Long settlementId);
 }

--- a/src/main/java/AIFinance/demo/settlement/service/SettlementResultService.java
+++ b/src/main/java/AIFinance/demo/settlement/service/SettlementResultService.java
@@ -1,0 +1,138 @@
+package AIFinance.demo.settlement.service;
+
+import AIFinance.demo.receipt.entity.ItemShare;
+import AIFinance.demo.receipt.entity.Receipt;
+import AIFinance.demo.receipt.entity.ReceiptItem;
+import AIFinance.demo.receipt.entity.enums.ReceiptStatus;
+import AIFinance.demo.receipt.repository.ItemShareRepository;
+import AIFinance.demo.receipt.repository.ReceiptItemRepository;
+import AIFinance.demo.receipt.repository.ReceiptRepository;
+import AIFinance.demo.settlement.dto.SettlementResultResponse;
+import AIFinance.demo.settlement.entity.Settlement;
+import AIFinance.demo.settlement.exception.SettlementException;
+import AIFinance.demo.settlement.exception.code.SettlementErrorCode;
+import AIFinance.demo.settlement.repository.SettlementRepository;
+import AIFinance.demo.settlement.repository.SettlementTransferRepository;
+import AIFinance.demo.trip.entity.Trip;
+import AIFinance.demo.trip.entity.TripMember;
+import AIFinance.demo.trip.entity.enums.TripMemberStatus;
+import AIFinance.demo.trip.entity.enums.TripStatus;
+import AIFinance.demo.trip.repository.TripMemberRepository;
+import AIFinance.demo.trip.repository.TripRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class SettlementResultService {
+
+    private final TripRepository tripRepository;
+    private final TripMemberRepository tripMemberRepository;
+    private final ReceiptRepository receiptRepository;
+    private final ReceiptItemRepository receiptItemRepository;
+    private final ItemShareRepository itemShareRepository;
+    private final SettlementRepository settlementRepository;
+    private final SettlementTransferRepository settlementTransferRepository;
+
+    public SettlementResultResponse.Result getSettlementResult(Long userId, Long tripId) {
+        Trip trip = tripRepository.findById(tripId)
+                .orElseThrow(() ->
+                        new SettlementException(SettlementErrorCode.TRIP_NOT_FOUND)
+                );
+
+        boolean isActiveMember =
+                tripMemberRepository.existsByTrip_IdAndUser_IdAndStatus(
+                        tripId,
+                        userId,
+                        TripMemberStatus.ACTIVE
+                );
+
+        if (!isActiveMember) {
+            throw new SettlementException(SettlementErrorCode.TRIP_MEMBER_REQUIRED);
+        }
+
+        if (trip.getStatus() != TripStatus.SETTLING
+                && trip.getStatus() != TripStatus.COMPLETED) {
+            throw new SettlementException(SettlementErrorCode.INVALID_TRIP_STATUS);
+        }
+
+        Settlement settlement = settlementRepository.findByTrip_Id(tripId)
+                .orElseThrow(() ->
+                        new SettlementException(SettlementErrorCode.SETTLEMENT_NOT_FOUND)
+                );
+
+        List<TripMember> members =
+                tripMemberRepository.findAllByTrip_IdAndStatus(
+                                tripId,
+                                TripMemberStatus.ACTIVE
+                        )
+                        .stream()
+                        .sorted(Comparator.comparing(TripMember::getId))
+                        .toList();
+
+        List<Receipt> receipts =
+                receiptRepository.findAllByTrip_IdAndStatus(
+                        tripId,
+                        ReceiptStatus.CONFIRMED
+                );
+
+        List<Long> receiptIds = receipts.stream()
+                .map(Receipt::getId)
+                .toList();
+
+        List<ReceiptItem> items = receiptIds.isEmpty()
+                ? List.of()
+                : receiptItemRepository.findByReceipt_IdIn(receiptIds);
+
+        List<Long> itemIds = items.stream()
+                .map(ReceiptItem::getId)
+                .toList();
+
+        List<ItemShare> shares = itemIds.isEmpty()
+                ? List.of()
+                : itemShareRepository.findByItem_IdIn(itemIds);
+
+        Map<Long, Long> payments = receipts.stream()
+                .collect(Collectors.groupingBy(
+                        receipt -> receipt.getPayerMember().getId(),
+                        Collectors.summingLong(Receipt::getTotalAmount)
+                ));
+
+        Map<Long, Long> burdens = shares.stream()
+                .collect(Collectors.groupingBy(
+                        share -> share.getTripMember().getId(),
+                        Collectors.summingLong(ItemShare::getShareAmount)
+                ));
+
+        List<SettlementResultResponse.Participant> participants =
+                members.stream()
+                        .map(member -> SettlementResultResponse.Participant.of(
+                                member,
+                                payments.getOrDefault(member.getId(), 0L),
+                                burdens.getOrDefault(member.getId(), 0L)
+                        ))
+                        .toList();
+
+        List<SettlementResultResponse.Transfer> transfers =
+                settlementTransferRepository
+                        .findAllBySettlement_IdOrderByIdAsc(settlement.getId())
+                        .stream()
+                        .map(SettlementResultResponse.Transfer::from)
+                        .toList();
+
+        return SettlementResultResponse.Result.of(
+                settlement,
+                participants,
+                transfers
+        );
+    }
+
+
+}


### PR DESCRIPTION
## 관련 이슈

Closes #54

## 작업 내용

- 정산 확정 이후 참여자가 정산 결과를 조회하는 API를 구현했습니다.
- 참여자별 결제액, 부담액, 정산 차액을 계산해 반환합니다.
- 생성된 송금 관계와 송금 진행 상태를 함께 반환합니다.

## 주요 변경 사항

- `GET /api/v1/trips/{tripId}/settlement` 구현
- 여행방 활성 참여자 여부 검증
- 여행 상태가 `SETTLING` 또는 `COMPLETED`인지 검증
- 확정된 영수증을 기준으로 참여자별 결제액 계산
- 상품별 부담 내역을 기준으로 참여자별 부담액 계산
- 정산 송금 내역 조회 기능 추가

## 동작 흐름

- 요청자의 여행방 참여 여부를 확인합니다.
- 여행 및 정산 상태를 확인합니다.
- 확정된 영수증과 부담 내역을 조회합니다.
- 참여자별 결제액, 부담액, 차액을 계산합니다.
- 정산 정보와 송금 내역을 반환합니다.

## 확인 사항

- `./gradlew.bat compileJava` 성공
- DB 연동 테스트는 추후 진행 예정

## AI 사용 여부

- [x] 사용함
- [ ] 사용하지 않음

### 사용한 AI 기능

- AI 기능/도구: ChatGPT Codex
- 사용 범위: API 구조 및 구현 검토
- 생성된 코드 직접 검토 여부: [x] Yes
- AI 생성 코드를 수정했나요?: [x] Yes

## 팀원이 확인해야 할 것

- 참여자별 결제액과 부담액 계산 기준
- 정산 결과 응답 구조