### PR TITLE
[FIX] 퇴장 참여자의 기존 금액을 최종 정산에 포함

### DIFF
--- a/src/main/java/AIFinance/demo/settlement/service/SettlementConfirmService.java
+++ b/src/main/java/AIFinance/demo/settlement/service/SettlementConfirmService.java
@@ -18,7 +18,6 @@ import AIFinance.demo.settlement.repository.SettlementRepository;
 import AIFinance.demo.settlement.repository.SettlementTransferRepository;
 import AIFinance.demo.trip.entity.Trip;
 import AIFinance.demo.trip.entity.TripMember;
-import AIFinance.demo.trip.entity.enums.TripMemberStatus;
 import AIFinance.demo.trip.entity.enums.TripStatus;
 import AIFinance.demo.trip.repository.TripMemberRepository;
 import AIFinance.demo.trip.repository.TripRepository;
@@ -60,7 +59,7 @@ public class SettlementConfirmService {
         List<Receipt> receipts = getSettlementReceipts(tripId);
         List<ReceiptItem> items = getReceiptItems(receipts);
         List<ItemShare> shares = getItemShares(items);
-        List<TripMember> members = tripMemberRepository.findAllByTrip_IdAndStatus(tripId, TripMemberStatus.ACTIVE);
+        List<TripMember> members = tripMemberRepository.findAllByTrip_Id(tripId);
 
         TripMember confirmer = findConfirmer(members, userId);
 

--- a/src/main/java/AIFinance/demo/settlement/service/SettlementResultService.java
+++ b/src/main/java/AIFinance/demo/settlement/service/SettlementResultService.java
@@ -69,10 +69,7 @@ public class SettlementResultService {
                 );
 
         List<TripMember> members =
-                tripMemberRepository.findAllByTrip_IdAndStatus(
-                                tripId,
-                                TripMemberStatus.ACTIVE
-                        )
+                tripMemberRepository.findAllByTrip_Id(tripId)
                         .stream()
                         .sorted(Comparator.comparing(TripMember::getId))
                         .toList();

--- a/src/main/java/AIFinance/demo/trip/repository/TripMemberRepository.java
+++ b/src/main/java/AIFinance/demo/trip/repository/TripMemberRepository.java
@@ -19,6 +19,8 @@ public interface TripMemberRepository extends JpaRepository<TripMember, Long> {
 
     List<TripMember> findAllByTrip_IdAndStatus(Long tripId, TripMemberStatus status);
 
+    List<TripMember> findAllByTrip_Id(Long tripId);
+
     int countByTrip_IdAndStatus(Long tripId, TripMemberStatus status);
 
     List<TripMember> findAllByUser_IdAndStatus(Long userId, TripMemberStatus status);


### PR DESCRIPTION
## 관련 이슈

Closes #62

## 작업 내용

- 퇴장 참여자의 기존 결제액과 부담액이 최종 정산에서 누락되지 않도록 정산 대상 조회 로직을 수정했습니다.

## 주요 변경 사항

- 여행 상태와 관계없이 전체 참여 이력을 조회하는 Repository 메서드를 추가했습니다.
- 정산 확정 시 `ACTIVE` 참여자와 `LEFT` 참여자를 모두 계산 대상에 포함했습니다.
- 정산 결과의 참여자 목록에도 퇴장 참여자가 포함되도록 수정했습니다.

## 동작 흐름

- 여행의 전체 참여 이력을 조회합니다.
- 활성 참여자와 퇴장 참여자의 기존 결제액 및 부담액을 집계합니다.
- 참여자별 차액을 계산하여 최종 송금 관계와 정산 결과를 생성합니다.