### PR TITLE
[FIX] 퇴장 참여자의 정산 결과 조회 허용

### DIFF
--- a/src/main/java/AIFinance/demo/settlement/service/SettlementResultService.java
+++ b/src/main/java/AIFinance/demo/settlement/service/SettlementResultService.java
@@ -15,7 +15,6 @@ import AIFinance.demo.settlement.repository.SettlementRepository;
 import AIFinance.demo.settlement.repository.SettlementTransferRepository;
 import AIFinance.demo.trip.entity.Trip;
 import AIFinance.demo.trip.entity.TripMember;
-import AIFinance.demo.trip.entity.enums.TripMemberStatus;
 import AIFinance.demo.trip.entity.enums.TripStatus;
 import AIFinance.demo.trip.repository.TripMemberRepository;
 import AIFinance.demo.trip.repository.TripRepository;
@@ -47,15 +46,16 @@ public class SettlementResultService {
                         new SettlementException(SettlementErrorCode.TRIP_NOT_FOUND)
                 );
 
-        boolean isActiveMember =
-                tripMemberRepository.existsByTrip_IdAndUser_IdAndStatus(
+        boolean isTripMember =
+                tripMemberRepository.findByTrip_IdAndUser_Id(
                         tripId,
-                        userId,
-                        TripMemberStatus.ACTIVE
-                );
+                        userId
+                ).isPresent();
 
-        if (!isActiveMember) {
-            throw new SettlementException(SettlementErrorCode.TRIP_MEMBER_REQUIRED);
+        if (!isTripMember) {
+            throw new SettlementException(
+                    SettlementErrorCode.TRIP_MEMBER_REQUIRED
+            );
         }
 
         if (trip.getStatus() != TripStatus.SETTLING


### PR DESCRIPTION
## 관련 이슈

Closes #64

## 작업 내용

- 퇴장 참여자가 기존 결제액이나 부담액으로 최종 정산에 포함된 경우, 본인의 정산 결과와 송금 내역을 조회할 수 있도록 권한 조건을 수정했습니다.

## 주요 변경 사항

- 정산 결과 조회 권한을 `ACTIVE` 참여자 여부가 아닌 여행 참여 이력 존재 여부로 변경했습니다.
- `LEFT` 상태의 참여자도 정산 결과를 조회할 수 있도록 수정했습니다.
- 여행에 참여한 이력이 없는 사용자의 접근 차단은 기존과 동일하게 유지했습니다.

## 동작 흐름

- 요청한 사용자의 여행 참여 이력을 조회합니다.
- 참여 이력이 없으면 `TRIP_MEMBER_REQUIRED` 오류를 반환합니다.
- 참여 이력이 있으면 현재 상태와 관계없이 정산 결과와 송금 목록을 반환합니다.

## 응답 예시

```json
{
  "isSuccess": true,
  "code": "SETTLEMENT_RESULT_RETRIEVED",
  "message": "정산 결과를 조회했습니다.",
  "result": {
    "settlementId": 1,
    "tripId": 1,
    "status": "CONFIRMED",
    "totalAmount": 60000,
    "confirmedAt": "2026-09-06T15:00:00",
    "completedAt": null,
    "participants": [
      {
        "tripMemberId": 2,
        "userId": 2,
        "nickname": "퇴장참여자",
        "paymentAmount": 0,
        "shareAmount": 20000,
        "differenceAmount": -20000
      }
    ],
    "transfers": [
      {
        "transferId": 1,
        "senderMemberId": 2,
        "senderNickname": "퇴장참여자",
        "receiverMemberId": 1,
        "receiverNickname": "방장",
        "amount": 20000,
        "status": "PENDING",
        "sentAt": null,
        "confirmedAt": null
      }
    ]
  }
}